### PR TITLE
dependencies and minio port change

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -34,9 +34,9 @@ DOCKER_INTERNAL_MINIO_API_PORT=10000
 DOCKER_INTERNAL_MINIO_DASHBOARD_PORT=9001
 
 # Local app processes use the host MinIO API endpoint. Do not use the console port.
-MINIO_ENDPOINT=http://localhost:10000
-MINIO_PUBLIC_ENDPOINT=http://localhost:10000
-MINIO_URL=http://localhost:10000
+MINIO_ENDPOINT=http://localhost:9001
+MINIO_PUBLIC_ENDPOINT=http://localhost:9001
+MINIO_URL=http://localhost:9001
 
 # =============================================================================
 # AUTH

--- a/.env.template
+++ b/.env.template
@@ -19,6 +19,10 @@ POSTGRES_USER=postgres
 POSTGRES_DATABASE=postgres
 S3_BUCKET_NAME=uiuc-chat
 QDRANT_COLLECTION_NAME=illinois-chat-qwen
+# Backend VectorDatabase (Vyriad Qdrant client); local dev usually matches main Qdrant + QDRANT_API_KEY
+VYRIAD_QDRANT_URL=http://localhost:6333
+VYRIAD_QDRANT_PORT=6333
+VYRIAD_QDRANT_API_KEY="your-strong-key-here"
 AWS_REGION=us-east-1
 
 # =============================================================================

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -56,14 +56,14 @@ For local dev uploads and ingest, use the MinIO API port, not the MinIO console 
 
 ```env
 # apps/frontend/.env
-MINIO_ENDPOINT=http://localhost:10000
-MINIO_PUBLIC_ENDPOINT=http://localhost:10000
-NEXT_PUBLIC_S3_ENDPOINT=http://localhost:10000
+MINIO_ENDPOINT=http://localhost:9001
+MINIO_PUBLIC_ENDPOINT=http://localhost:9001
+NEXT_PUBLIC_S3_ENDPOINT=http://localhost:9001
 
 # apps/backend/.env
-MINIO_URL=http://localhost:10000
-MINIO_ENDPOINT=http://localhost:10000
-MINIO_PUBLIC_ENDPOINT=http://localhost:10000
+MINIO_URL=http://localhost:9001
+MINIO_ENDPOINT=http://localhost:9001
+MINIO_PUBLIC_ENDPOINT=http://localhost:9001
 ```
 
 `http://localhost:9001` is the MinIO management console and should not be used for S3 uploads.
@@ -134,7 +134,7 @@ npm run local
 | Frontend            | http://localhost:3000  | Next.js application       |
 | Backend API         | http://localhost:8000  | Flask API                 |
 | Keycloak            | http://localhost:8080  | Authentication service    |
-| MinIO API           | http://localhost:10000 | Object storage API        |
+| MinIO API           | http://localhost:9001 | Object storage API        |
 | MinIO Console       | http://localhost:9001  | Object storage management |
 | RabbitMQ Management | http://localhost:15672 | Message queue management  |
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Inside Docker, services talk to each other through Compose names such as `backen
 Use the MinIO API endpoint for uploads and presigned URLs, not the MinIO console port.
 
 - Full Docker/e2e API: `http://localhost:9000`
-- Local development API: `http://localhost:10000`
+- Local development API: `http://localhost:9001`
 - MinIO console: `http://localhost:9001`
 
 ## Common Commands

--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -21,9 +21,9 @@ QDRANT_API_KEY="your-strong-key-here"
 
 # MinIO / S3
 LOCAL_MINIO=true
-MINIO_URL=http://localhost:10000
-MINIO_ENDPOINT=http://localhost:10000
-MINIO_PUBLIC_ENDPOINT=http://localhost:10000
+MINIO_URL=http://localhost:9001
+MINIO_ENDPOINT=http://localhost:9001
+MINIO_PUBLIC_ENDPOINT=http://localhost:9001
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=minioadmin
 AWS_SECRET_ACCESS_KEY=minioadmin

--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -19,6 +19,11 @@ QDRANT_COLLECTION_NAME=illinois-chat-qwen
 QDRANT_URL=http://localhost:6333
 QDRANT_API_KEY="your-strong-key-here"
 
+# Vyriad Qdrant
+VYRIAD_QDRANT_URL=http://localhost:6333
+VYRIAD_QDRANT_PORT=6333
+VYRIAD_QDRANT_API_KEY="your-strong-key-here"
+
 # MinIO / S3
 LOCAL_MINIO=true
 MINIO_URL=http://localhost:9001

--- a/apps/backend/ai_ta_backend/rabbitmq/requirements.txt
+++ b/apps/backend/ai_ta_backend/rabbitmq/requirements.txt
@@ -1,4 +1,4 @@
-psycopg2
+psycopg2-binary
 openai==1.63.0
 pandas
 tiktoken==0.9.0

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -20,7 +20,7 @@ typing_extensions==4.12.2
 cryptography==44.0.1
 pika==1.3.2
 sql==0.4.0
-psycopg2-binary==2.9.7
+psycopg2-binary
 yt-dlp==2024.7.16
 
 # Utils

--- a/infra/scripts/start-dev.sh
+++ b/infra/scripts/start-dev.sh
@@ -99,6 +99,10 @@ ensure_local_app_envs() {
 	append_env_if_missing "$backend_env" "QDRANT_COLLECTION_NAME" "$qdrant_collection"
 	append_env_if_missing "$backend_env" "QDRANT_URL" "http://localhost:6333"
 	append_env_if_missing "$backend_env" "QDRANT_API_KEY" "$qdrant_api_key"
+	# VectorDatabase (Flask); same pattern as infra/docker/docker-compose.yaml backend service
+	append_env_if_missing "$backend_env" "VYRIAD_QDRANT_URL" "http://localhost:6333"
+	append_env_if_missing "$backend_env" "VYRIAD_QDRANT_PORT" "6333"
+	append_env_if_missing "$backend_env" "VYRIAD_QDRANT_API_KEY" "$qdrant_api_key"
 	append_env_if_missing "$backend_env" "LOCAL_MINIO" "true"
 	append_env_if_missing "$backend_env" "MINIO_URL" "http://localhost:9001"
 	append_env_if_missing "$backend_env" "MINIO_ENDPOINT" "http://localhost:9001"

--- a/infra/scripts/start-dev.sh
+++ b/infra/scripts/start-dev.sh
@@ -100,9 +100,9 @@ ensure_local_app_envs() {
 	append_env_if_missing "$backend_env" "QDRANT_URL" "http://localhost:6333"
 	append_env_if_missing "$backend_env" "QDRANT_API_KEY" "$qdrant_api_key"
 	append_env_if_missing "$backend_env" "LOCAL_MINIO" "true"
-	append_env_if_missing "$backend_env" "MINIO_URL" "http://localhost:10000"
-	append_env_if_missing "$backend_env" "MINIO_ENDPOINT" "http://localhost:10000"
-	append_env_if_missing "$backend_env" "MINIO_PUBLIC_ENDPOINT" "http://localhost:10000"
+	append_env_if_missing "$backend_env" "MINIO_URL" "http://localhost:9001"
+	append_env_if_missing "$backend_env" "MINIO_ENDPOINT" "http://localhost:9001"
+	append_env_if_missing "$backend_env" "MINIO_PUBLIC_ENDPOINT" "http://localhost:9001"
 	append_env_if_missing "$backend_env" "AWS_REGION" "$aws_region"
 	append_env_if_missing "$backend_env" "AWS_ACCESS_KEY_ID" "$aws_access_key"
 	append_env_if_missing "$backend_env" "AWS_SECRET_ACCESS_KEY" "$aws_secret_key"
@@ -152,9 +152,9 @@ ensure_local_app_envs() {
 	append_env_if_missing "$frontend_env" "AWS_ACCESS_KEY_ID" "$aws_access_key"
 	append_env_if_missing "$frontend_env" "AWS_SECRET_ACCESS_KEY" "$aws_secret_key"
 	append_env_if_missing "$frontend_env" "S3_BUCKET_NAME" "$s3_bucket"
-	append_env_if_missing "$frontend_env" "MINIO_ENDPOINT" "http://localhost:10000"
-	append_env_if_missing "$frontend_env" "MINIO_PUBLIC_ENDPOINT" "http://localhost:10000"
-	append_env_if_missing "$frontend_env" "NEXT_PUBLIC_S3_ENDPOINT" "http://localhost:10000"
+	append_env_if_missing "$frontend_env" "MINIO_ENDPOINT" "http://localhost:9001"
+	append_env_if_missing "$frontend_env" "MINIO_PUBLIC_ENDPOINT" "http://localhost:9001"
+	append_env_if_missing "$frontend_env" "NEXT_PUBLIC_S3_ENDPOINT" "http://localhost:9001"
 	append_env_if_missing "$frontend_env" "QDRANT_COLLECTION_NAME" "$qdrant_collection"
 	append_env_if_missing "$frontend_env" "QDRANT_URL" "http://localhost:6333"
 	append_env_if_missing "$frontend_env" "QDRANT_API_KEY" "$qdrant_api_key"
@@ -186,7 +186,7 @@ ensure_local_app_envs() {
 	append_env_if_missing "$crawlee_env" "AWS_ACCESS_KEY_ID" "$aws_access_key"
 	append_env_if_missing "$crawlee_env" "AWS_SECRET_ACCESS_KEY" "$aws_secret_key"
 	append_env_if_missing "$crawlee_env" "S3_BUCKET_NAME" "$s3_bucket"
-	append_env_if_missing "$crawlee_env" "MINIO_ENDPOINT" "http://localhost:10000"
+	append_env_if_missing "$crawlee_env" "MINIO_ENDPOINT" "http://localhost:9001"
 	append_env_if_missing "$crawlee_env" "NO_CRAWL" ""
 	append_env_if_missing "$crawlee_env" "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH" ""
 	append_env_if_missing "$crawlee_env" "OPENAI_API_KEY" ""
@@ -276,9 +276,9 @@ DOCKER_INTERNAL_MINIO_API_PORT=10000
 DOCKER_INTERNAL_MINIO_DASHBOARD_PORT=9001
 PUBLIC_MINIO_API_PORT=10000
 PUBLIC_MINIO_DASHBOARD_PORT=9001
-MINIO_ENDPOINT=http://localhost:10000
-MINIO_PUBLIC_ENDPOINT=http://localhost:10000
-MINIO_URL=http://localhost:10000
+MINIO_ENDPOINT=http://localhost:9001
+MINIO_PUBLIC_ENDPOINT=http://localhost:9001
+MINIO_URL=http://localhost:9001
 
 # RabbitMQ Configuration
 RABBITMQ_USER=guest


### PR DESCRIPTION
- Adjust psycopg2 dependency
- Minio Port
- Vyraid envs are needed otherwise error 

```
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/cwang138/Documents/Projects/chatUIUC/self-hostable-uiuc-chat/apps/backend/ai_ta_backend/database/vector.py", line 31, in __init__
    self.vyriad_qdrant_client = QdrantClient(url=os.environ['VYRIAD_QDRANT_URL'],
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 714, in __getitem__
KeyError: 'VYRIAD_QDRANT_URL'
INFO:werkzeug:127.0.0.1 - - [11/May/2026 11:55:42] "POST /ingest HTTP/1.1" 200 -
```