### PR TITLE
ci: fix invalid trunk-action check-mode and wire up real frontend tests

### DIFF
--- a/.github/workflows/illinois-chat-dev.yml
+++ b/.github/workflows/illinois-chat-dev.yml
@@ -18,11 +18,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Trunk
-        uses: trunk-io/trunk-action@v1
-        with:
-          check-mode: true
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: read
+  checks: write # trunk-action posts lint results as check-run annotations
 
 jobs:
   trunk-and-tests:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,26 +7,43 @@ on:
       - illinois-chat
       - main
 
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   trunk-and-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout monorepo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install Trunk
+      # check-mode is auto-detected from the event (pull_request)
+      - name: Trunk check
         uses: trunk-io/trunk-action@v1
-        with:
-          check-mode: true
 
       # Backend tests placeholder
       - name: Backend tests
         run: |
           echo "TODO: add backend tests (e.g., pytest) here"
 
-      # Frontend tests placeholder
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: apps/frontend
+        run: npm ci
+
       - name: Frontend tests
-        run: |
-          echo "TODO: add frontend tests (e.g., npm test) here"
+        working-directory: apps/frontend
+        run: npm run test:coverage:check

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -13,11 +13,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Trunk
-        uses: trunk-io/trunk-action@v1
-        with:
-          check-mode: true
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -46,6 +46,12 @@ lint:
         - .DS_Store
         - .vscode/**/*
         - README.md
+    # apps/frontend pins prettier 2.8.8 + prettier-plugin-tailwindcss 0.2.x via
+    # prettier.config.cjs; trunk's hermetic prettier 3 cannot load that config
+    # (exit 2 on every file). The app enforces its own formatting (npm run format).
+    - linters: [prettier]
+      paths:
+        - apps/frontend/**
 actions:
   enabled:
     - trunk-announce

--- a/apps/frontend/__tests__/pages/api/UIUC-api/__tests__/s3Routes.test.ts
+++ b/apps/frontend/__tests__/pages/api/UIUC-api/__tests__/s3Routes.test.ts
@@ -23,6 +23,8 @@ vi.mock('@aws-sdk/s3-request-presigner', () => ({
 vi.mock('~/utils/s3Client', () => ({
   s3Client: {},
   vyriadMinioClient: null,
+  getPresignedUrlClient: vi.fn(() => ({})),
+  getPresignedUrlVyriadClient: vi.fn(() => null),
 }))
 
 import getPresignedUrlHandler from '~/pages/api/UIUC-api/getPresignedUrl'

--- a/apps/frontend/__tests__/pages/api/UIUC-api/__tests__/uploadToS3.test.ts
+++ b/apps/frontend/__tests__/pages/api/UIUC-api/__tests__/uploadToS3.test.ts
@@ -14,6 +14,8 @@ vi.mock('@aws-sdk/s3-presigned-post', () => ({
 vi.mock('~/utils/s3Client', () => ({
   s3Client: {},
   vyriadMinioClient: {},
+  getPresignedUrlClient: vi.fn(() => ({})),
+  getPresignedUrlVyriadClient: vi.fn(() => ({})),
 }))
 
 vi.mock('~/pages/api/authorization', () => ({

--- a/apps/frontend/src/utils/__tests__/appRouterAuth.test.ts
+++ b/apps/frontend/src/utils/__tests__/appRouterAuth.test.ts
@@ -11,6 +11,7 @@ describe('withAppRouterAuth', () => {
     }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -29,8 +30,12 @@ describe('withAppRouterAuth', () => {
   it('attaches user and calls handler when token verifies', async () => {
     const verifyTokenAsync = vi.fn().mockResolvedValue({ sub: 'u1' })
     const getKeycloakBaseFromHost = vi.fn(() => 'https://kc/')
+    const getKeycloakIssuerUrl = vi.fn(() => 'https://kc/realms/test')
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
-    vi.doMock('~/utils/authHelpers', () => ({ getKeycloakBaseFromHost }))
+    vi.doMock('~/utils/authHelpers', () => ({
+      getKeycloakBaseFromHost,
+      getKeycloakIssuerUrl,
+    }))
 
     vi.resetModules()
     const { withAppRouterAuth } = await import('../appRouterAuth')
@@ -47,7 +52,12 @@ describe('withAppRouterAuth', () => {
 
     const res = await wrapped(req)
     expect(getKeycloakBaseFromHost).toHaveBeenCalledWith('example.com')
-    expect(verifyTokenAsync).toHaveBeenCalledWith('t', 'https://kc/')
+    expect(getKeycloakIssuerUrl).toHaveBeenCalledWith('example.com')
+    expect(verifyTokenAsync).toHaveBeenCalledWith(
+      't',
+      'https://kc/',
+      'https://kc/realms/test',
+    )
     await expect(res.json()).resolves.toMatchObject({ user: { sub: 'u1' } })
   })
 
@@ -61,6 +71,7 @@ describe('withAppRouterAuth', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -84,6 +95,7 @@ describe('withAppRouterAuth', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -105,6 +117,7 @@ describe('withAppRouterAuth', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()

--- a/apps/frontend/src/utils/__tests__/authHelpers.test.ts
+++ b/apps/frontend/src/utils/__tests__/authHelpers.test.ts
@@ -74,4 +74,24 @@ describe('keycloak base URL helpers', () => {
     )
     vi.stubEnv('KEYCLOAK_URL', '')
   })
+
+  it('getKeycloakIssuerUrl prefers NEXT_PUBLIC_KEYCLOAK_URL when set', () => {
+    vi.stubEnv('KEYCLOAK_URL', '')
+    vi.stubEnv('NEXT_PUBLIC_KEYCLOAK_URL', 'https://override.example/')
+    expect(getKeycloakIssuerUrl('example.com')).toBe(
+      'https://override.example/realms/illinois_chat_realm',
+    )
+    vi.stubEnv('NEXT_PUBLIC_KEYCLOAK_URL', '')
+  })
+
+  it('getKeycloakIssuerUrl handles known and custom hostnames', () => {
+    vi.stubEnv('KEYCLOAK_URL', '')
+    vi.stubEnv('NEXT_PUBLIC_KEYCLOAK_URL', '')
+    expect(getKeycloakIssuerUrl('uiuc.chat')).toBe(
+      'https://login.uiuc.chat/realms/illinois_chat_realm',
+    )
+    expect(getKeycloakIssuerUrl('example.com')).toBe(
+      'https://example.com/keycloak/realms/illinois_chat_realm',
+    )
+  })
 })

--- a/apps/frontend/src/utils/__tests__/authMiddleware.test.ts
+++ b/apps/frontend/src/utils/__tests__/authMiddleware.test.ts
@@ -23,6 +23,7 @@ describe('authMiddleware', () => {
     }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -42,8 +43,12 @@ describe('authMiddleware', () => {
   it('withAuth attaches user and calls handler when token verifies', async () => {
     const verifyTokenAsync = vi.fn().mockResolvedValue({ sub: 'u1' })
     const getKeycloakBaseFromHost = vi.fn(() => 'https://kc/')
+    const getKeycloakIssuerUrl = vi.fn(() => 'https://kc/realms/test')
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
-    vi.doMock('~/utils/authHelpers', () => ({ getKeycloakBaseFromHost }))
+    vi.doMock('~/utils/authHelpers', () => ({
+      getKeycloakBaseFromHost,
+      getKeycloakIssuerUrl,
+    }))
 
     vi.resetModules()
     const { withAuth } = await import('../authMiddleware')
@@ -58,7 +63,12 @@ describe('authMiddleware', () => {
 
     await wrapped(req, res)
     expect(getKeycloakBaseFromHost).toHaveBeenCalledWith('example.com')
-    expect(verifyTokenAsync).toHaveBeenCalledWith('t', 'https://kc/')
+    expect(getKeycloakIssuerUrl).toHaveBeenCalledWith('example.com')
+    expect(verifyTokenAsync).toHaveBeenCalledWith(
+      't',
+      'https://kc/',
+      'https://kc/realms/test',
+    )
     expect(req.user).toEqual({ sub: 'u1' })
     expect(handler).toHaveBeenCalledWith(req, res)
   })
@@ -73,6 +83,7 @@ describe('authMiddleware', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -95,6 +106,7 @@ describe('authMiddleware', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -115,6 +127,7 @@ describe('authMiddleware', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -145,6 +158,7 @@ describe('authMiddleware', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -166,6 +180,7 @@ describe('authMiddleware', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -189,6 +204,7 @@ describe('authMiddleware', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -210,6 +226,7 @@ describe('authMiddleware', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -229,6 +246,7 @@ describe('authMiddleware', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()
@@ -252,6 +270,7 @@ describe('authMiddleware', () => {
     vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
     vi.doMock('~/utils/authHelpers', () => ({
       getKeycloakBaseFromHost: vi.fn(() => 'https://kc/'),
+      getKeycloakIssuerUrl: vi.fn(() => 'https://kc/realms/test'),
     }))
 
     vi.resetModules()

--- a/apps/frontend/src/utils/__tests__/s3Client.test.ts
+++ b/apps/frontend/src/utils/__tests__/s3Client.test.ts
@@ -100,4 +100,59 @@ describe('s3Client', () => {
       }),
     )
   })
+
+  it('getPresignedUrlClient falls back to a region-only client when credentials are missing', async () => {
+    const ctor = vi.fn()
+    vi.doMock('@aws-sdk/client-s3', () => ({ S3Client: ctor }))
+
+    vi.stubEnv('AWS_REGION', '')
+    vi.stubEnv('AWS_KEY', '')
+    vi.stubEnv('AWS_SECRET', '')
+
+    vi.resetModules()
+    const mod = await import('../s3Client')
+    ctor.mockClear()
+    mod.getPresignedUrlClient()
+    expect(ctor).toHaveBeenCalledWith({ region: 'us-east-1' })
+  })
+
+  it('getPresignedUrlVyriadClient builds a client from VYRIAD_MINIO env vars', async () => {
+    const ctor = vi.fn()
+    vi.doMock('@aws-sdk/client-s3', () => ({ S3Client: ctor }))
+
+    vi.stubEnv('VYRIAD_MINIO_KEY', 'vk')
+    vi.stubEnv('VYRIAD_MINIO_SECRET', 'vs')
+    vi.stubEnv('VYRIAD_MINIO_ENDPOINT', 'http://vyriad-minio:9000')
+    vi.stubEnv('VYRIAD_MINIO_PUBLIC_ENDPOINT', 'http://localhost:9002')
+    vi.stubEnv('VYRIAD_MINIO_REGION', '')
+
+    vi.resetModules()
+    const mod = await import('../s3Client')
+    ctor.mockClear()
+    mod.getPresignedUrlVyriadClient()
+    expect(ctor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: 'us-east-1',
+        endpoint: 'http://localhost:9002',
+        credentials: { accessKeyId: 'vk', secretAccessKey: 'vs' },
+        forcePathStyle: true,
+      }),
+    )
+  })
+
+  it('getPresignedUrlVyriadClient falls back to the module client when env is missing', async () => {
+    const ctor = vi.fn()
+    vi.doMock('@aws-sdk/client-s3', () => ({ S3Client: ctor }))
+
+    vi.stubEnv('VYRIAD_MINIO_KEY', '')
+    vi.stubEnv('VYRIAD_MINIO_SECRET', '')
+    vi.stubEnv('VYRIAD_MINIO_ENDPOINT', '')
+    vi.stubEnv('VYRIAD_MINIO_PUBLIC_ENDPOINT', '')
+
+    vi.resetModules()
+    const mod = await import('../s3Client')
+    ctor.mockClear()
+    expect(mod.getPresignedUrlVyriadClient()).toBe(mod.vyriadMinioClient)
+    expect(ctor).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary

Makes `PR Checks` actually work and actually test the frontend. Every run in this repo's history had failed within ~15s — before linting or testing anything.

### 1. Fix the invalid trunk-action input (all 3 workflows)

All three workflows passed `check-mode: true` to `trunk-io/trunk-action@v1`, but that input only accepts `all`, `none`, `populate_cache_only`, `pull_request`, `push`, or `trunk_merge`, so the action's setup script exited 1 immediately:

```
check-mode must be one of: 'all', 'none', 'populate_cache_only', 'pull_request', 'push', or 'trunk_merge'
```

- **pr-checks.yml**: drop the invalid input (auto-detects `pull_request` mode), grant `checks: write` (trunk posts results as a check run; without it the action 403s and fails even with zero findings), add concurrency + timeout.
- **illinois-chat-dev.yml / release-images.yml**: remove the broken `Install Trunk` step entirely — it gated deploys/releases on nothing and guaranteed failure at the first step.

### 2. Wire up the real frontend test suite

Replace the `echo TODO` placeholder with the same gate `uiuc-chat-frontend` ran on PRs: Node 20 + `npm ci` + `npm run test:coverage:check` in `apps/frontend` (vitest + per-directory coverage thresholds). Backend tests remain a placeholder.

### 3. Fix the 14 pre-existing test failures the suite then exposes

`apps/frontend` had diverged from `uiuc-chat-frontend` in four utils (`s3Client`, `authHelpers`, `authMiddleware`, `keycloakClient`) without updating their tests — 14 tests in 4 files fail on bare `monorepo`:

- auth wrappers now pass a third `issuerUrl` arg (from new `getKeycloakIssuerUrl`) to `verifyTokenAsync`; the tests' `authHelpers` mocks lacked that export, so the wrappers threw before verifying. Mock it and assert the 3-arg call.
- `uploadToS3` switched to `getPresignedUrlClient()` / `getPresignedUrlVyriadClient()`; the module mocks lacked the getters, so the handler 500'd. Extend the mocks.

### 4. Close the `src/utils` 100% coverage gap the divergence left

New tests for `getKeycloakIssuerUrl`'s env/uiuc.chat/custom-host branches and `s3Client`'s presigned-URL getter fallbacks.

### 5. Exclude `apps/frontend` from trunk's prettier

The app pins prettier 2.8.8 + prettier-plugin-tailwindcss 0.2.x via `prettier.config.cjs`; trunk's hermetic prettier 3.2.5 cannot load that config and exits 2 on every frontend file regardless of formatting. The app enforces its own formatting with its pinned prettier. All other trunk linters keep covering `apps/frontend`.

## Verification

Local run on this branch (Node 20.11.0): **1,952/1,952 tests pass**, all coverage gates OK:

```
src/utils      lines  100.00%  (6205/6205)  min 100%  OK
src/hooks      lines   96.96%  (1629/1680)  min 95%   OK
src/pages/api  lines   90.76%  (5316/5857)  min 90%   OK
src/app/api    lines   91.05%  (834/916)    min 90%   OK
```

## Test plan

- [ ] `PR Checks` on this PR gets past the trunk step and runs the frontend suite (this PR exercises its own fix).
- [ ] Next push to `illinois-chat` / next release publishes images without dying at the trunk step.

> Note: the same fix commits are cherry-picked onto #40 and #41 so their checks are meaningful before this merges; git dedupes them on merge.
