### PR TITLE
fix(backend): unify MinIO client on MINIO_URL env var

### DIFF
--- a/apps/backend/ai_ta_backend/database/aws.py
+++ b/apps/backend/ai_ta_backend/database/aws.py
@@ -11,8 +11,8 @@ class AWSStorage:
     s3_config = {}
 
     # If running against local MinIO
-    if os.environ.get("LOCAL_MINIO") == "true" and os.environ.get("MINIO_ENDPOINT"):
-        s3_config["endpoint_url"] = os.environ["MINIO_ENDPOINT"]
+    if os.environ.get("LOCAL_MINIO") == "true" and os.environ.get("MINIO_URL"):
+        s3_config["endpoint_url"] = os.environ["MINIO_URL"]
     
     # AWS credentials
     if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):

--- a/apps/backend/ai_ta_backend/utils/pubmed_extraction.py
+++ b/apps/backend/ai_ta_backend/utils/pubmed_extraction.py
@@ -26,7 +26,7 @@ from posthog import Posthog
 #     supabase_key=os.getenv('SUPABASE_API_KEY')  # type: ignore
 # )
 
-# MINIO_CLIENT = Minio(os.environ['MINIO_ENDPOINT'],
+# MINIO_CLIENT = Minio(os.environ['MINIO_URL'],
 #                      access_key=os.environ['MINIO_ACCESS_KEY'],
 #                      secret_key=os.environ['MINIO_SECRET'],
 #                      secure=True)
@@ -52,7 +52,7 @@ def extractPubmedData():
         )
 
   if 'MINIO_CLIENT' not in globals():
-        MINIO_CLIENT = Minio(os.environ['MINIO_ENDPOINT'],
+        MINIO_CLIENT = Minio(os.environ['MINIO_URL'],
                             access_key=os.environ['MINIO_ACCESS_KEY'],
                             secret_key=os.environ['MINIO_SECRET'],
                             secure=True)

--- a/apps/backend/ai_ta_backend/utils/pubmed_vectorize.py
+++ b/apps/backend/ai_ta_backend/utils/pubmed_vectorize.py
@@ -73,7 +73,7 @@ def extract_text_from_pdf(file_path, s3_path):
 def process_pdf(key, bucket, temp_dir):
     """Process a single PDF file - for parallel execution"""
     minio_client = Minio(
-        endpoint=os.environ['MINIO_ENDPOINT'],
+        endpoint=os.environ['MINIO_URL'],
         access_key=os.environ['MINIO_ACCESS_KEY'],
         secret_key=os.environ['MINIO_SECRET_KEY'],
         secure=os.environ.get('MINIO_SECURE', 'false').lower() == 'true'
@@ -103,7 +103,7 @@ class MinioClient:
     def __init__(self):
         """Initialize MinIO client."""
         self.client = Minio(
-            endpoint=os.environ['MINIO_ENDPOINT'],
+            endpoint=os.environ['MINIO_URL'],
             access_key=os.environ['MINIO_ACCESS_KEY'],
             secret_key=os.environ['MINIO_SECRET_KEY'],
             secure=os.environ.get('MINIO_SECURE', 'false').lower() == 'true'


### PR DESCRIPTION
Closes #54

## Summary
Ports [Center-for-AI-Innovation/ai-ta-backend#448](https://github.com/Center-for-AI-Innovation/ai-ta-backend/pull/448) to the monorepo.

- Use `MINIO_URL` instead of `MINIO_ENDPOINT` in `aws.py`, `pubmed_extraction.py`, and `pubmed_vectorize.py`
- Aligns backend S3/MinIO config with ingest worker expectations

**Base:** `monorepo`

## Test plan
- [ ] Start local dev stack with `LOCAL_MINIO=true` and confirm backend can reach MinIO
- [ ] Verify ingest worker still reads `MINIO_URL` correctly

Made with [Cursor](https://cursor.com)