### PR TITLE
fix(frontend): debounce temperature slider conversation updates

### DIFF
--- a/apps/frontend/src/components/Chat/ModelParams.tsx
+++ b/apps/frontend/src/components/Chat/ModelParams.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
 // import { ModelSelect } from './ModelSelect'
 import { TemperatureSlider } from './Temperature'
 import { createStyles } from '@mantine/core'
@@ -62,17 +63,23 @@ export const ModelParams = ({
     setIsChecked(event.target.checked)
   }
 
+  const debouncedUpdateTemperature = useDebouncedCallback(
+    (temperature: number) => {
+      if (!selectedConversation) return
+      handleUpdateConversation(selectedConversation, {
+        key: 'temperature',
+        value: temperature,
+      })
+    },
+    400,
+  )
+
   return (
     <div className="backdrop-filter-[blur(10px)] w-full rounded-lg ">
       <div className="flex h-full flex-col space-y-4 rounded-lg p-4">
         <TemperatureSlider
           label={t('Temperature')}
-          onChangeTemperature={(temperature) =>
-            handleUpdateConversation(selectedConversation, {
-              key: 'temperature',
-              value: temperature,
-            })
-          }
+          onChangeTemperature={debouncedUpdateTemperature}
         />
       </div>
     </div>


### PR DESCRIPTION
Closes #57

## Summary
Addresses [Center-for-AI-Innovation/uiuc-chat-frontend#418](https://github.com/Center-for-AI-Innovation/uiuc-chat-frontend/issues/418).

- Debounce `handleUpdateConversation` calls from the temperature slider (400ms)
- Slider UI remains responsive; server writes are batched

**Base:** `monorepo`

## Test plan
- [ ] Open chat settings and drag temperature slider rapidly
- [ ] Confirm conversation update API is not called on every tick
- [ ] Confirm final temperature value persists after releasing slider

Made with [Cursor](https://cursor.com)