### PR TITLE
fix(frontend): add OIDC silent renew for session timeout

### DIFF
--- a/apps/frontend/src/pages/silent-renew.tsx
+++ b/apps/frontend/src/pages/silent-renew.tsx
@@ -1,0 +1,32 @@
+import { UserManager, WebStorageStateStore } from 'oidc-client-ts'
+import { useEffect, useRef } from 'react'
+import { getKeycloakBaseUrl } from '~/utils/authHelpers'
+
+/**
+ * OIDC silent-renew callback page. Loaded in a hidden iframe when the access
+ * token expires; must call signinSilentCallback() to complete the renewal.
+ */
+export default function SilentRenew() {
+  const handled = useRef(false)
+
+  useEffect(() => {
+    if (handled.current || typeof window === 'undefined') return
+    handled.current = true
+
+    const userManager = new UserManager({
+      authority: `${getKeycloakBaseUrl()}realms/${
+        process.env.NEXT_PUBLIC_KEYCLOAK_REALM
+      }`,
+      client_id: process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID || 'uiucchat',
+      redirect_uri: window.location.origin,
+      silent_redirect_uri: `${window.location.origin}/silent-renew`,
+      userStore: new WebStorageStateStore({ store: window.localStorage }),
+    })
+
+    void userManager.signinSilentCallback().catch((err: unknown) => {
+      console.error('Silent renew callback failed:', err)
+    })
+  }, [])
+
+  return null
+}

--- a/apps/frontend/src/providers/AuthCookie.tsx
+++ b/apps/frontend/src/providers/AuthCookie.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 
 import { CookieStorage } from '~/providers/CookieStorage'
@@ -9,6 +9,7 @@ export function AuthCookie({ children }: { children: React.ReactNode }) {
   const router = useRouter()
   const [cookieWritten, setCookieWritten] = useState(false)
   const cookieStore = new CookieStorage()
+  const retriedLogin = useRef(false)
 
   useEffect(() => {
     try {
@@ -27,13 +28,20 @@ export function AuthCookie({ children }: { children: React.ReactNode }) {
     }
   }, [auth, cookieStore, router])
 
-  // TODO make full pages with styling
-  // switch (auth.activeNavigator) {
-  //   case "signinSilent":
-  //     return <div>Signing you in...</div>;
-  //   case "signoutRedirect":
-  //     return <div>Signing you out...</div>;
-  // }
+  useEffect(() => {
+    if (!auth.error || retriedLogin.current || auth.activeNavigator) return
+    retriedLogin.current = true
+    console.warn('Auth error, redirecting to login:', auth.error.message)
+    void auth.signinRedirect()
+  }, [auth.error, auth.activeNavigator, auth])
+
+  if (auth.activeNavigator === 'signinSilent') {
+    return null
+  }
+
+  if (auth.activeNavigator === 'signoutRedirect') {
+    return <div>Signing you out...</div>
+  }
 
   // Don't render children until auth is loaded AND cookie is written
   if (auth.isAuthenticated && !cookieWritten) {
@@ -41,7 +49,7 @@ export function AuthCookie({ children }: { children: React.ReactNode }) {
   }
 
   if (auth.error) {
-    return <div>Oops... {auth.error.message}</div>
+    return <div>Session expired, redirecting to login...</div>
   }
 
   // At this point, cookieWritten is guaranteed to be true

--- a/apps/frontend/src/providers/KeycloakProvider.tsx
+++ b/apps/frontend/src/providers/KeycloakProvider.tsx
@@ -92,7 +92,12 @@ export const KeycloakProvider = ({ children }: AuthProviderProps) => {
     if (typeof window !== 'undefined') {
       const baseUrl = getBaseUrl()
       const searchParams = new URLSearchParams(window.location.search)
-      setIsAuthCallback(searchParams.has('code') && searchParams.has('state'))
+      const isSilentRenewPath = window.location.pathname === '/silent-renew'
+      setIsAuthCallback(
+        !isSilentRenewPath &&
+          searchParams.has('code') &&
+          searchParams.has('state'),
+      )
       setIsMounted(true)
 
       // const cookieStore = new CookieStorage({
@@ -112,6 +117,7 @@ export const KeycloakProvider = ({ children }: AuthProviderProps) => {
           store: window.localStorage,
         }),
         automaticSilentRenew: true,
+        accessTokenExpiringNotificationTimeInSeconds: 60,
       }))
 
       // Only save the path when component mounts if we're not on the callback URL


### PR DESCRIPTION
Closes #58

## Summary
Addresses [Center-for-AI-Innovation/uiuc-chat-frontend#688](https://github.com/Center-for-AI-Innovation/uiuc-chat-frontend/issues/688).

- Add `/silent-renew` callback page for OIDC token refresh
- Retry login on silent renew failure instead of bricking the UI
- Exclude silent-renew path from auth callback handling
- Notify 60s before access token expiry

**Base:** `monorepo`

## Test plan
- [ ] Log in and leave the app idle past token expiry
- [ ] Confirm session renews silently without API error screen
- [ ] Confirm redirect to login if silent renew fails

Made with [Cursor](https://cursor.com)