### PR TITLE
feat(scrape): reusable scrape parameters, per-run document tracking, and re-ingest controls

### DIFF
--- a/apps/backend/ai_ta_backend/database/sql.py
+++ b/apps/backend/ai_ta_backend/database/sql.py
@@ -110,6 +110,24 @@ class SQLDatabase:
         finally:
             session.close()
 
+    def getDocumentsForScrapeRun(self, scrape_metadata_run_id):
+        """Return [{document_id, url, s3_path}] for docs linked to a scrape run.
+        Used by /finalizeScrapeRun to compute which docs are 'missing' after a
+        re-crawl and should be deleted."""
+        query = (
+            select(
+                models.ScrapingMetadataDocuments.document_id,
+                models.Document.url,
+                models.Document.s3_path,
+            )
+            .join(models.Document,
+                  models.Document.id == models.ScrapingMetadataDocuments.document_id)
+            .where(models.ScrapingMetadataDocuments.scrape_metadata_run_id == scrape_metadata_run_id)
+        )
+        with self.get_session() as session:
+            rows = session.execute(query).all()
+            return [{"document_id": r[0], "url": r[1], "s3_path": r[2]} for r in rows]
+
     def getAllMaterialsForCourse(self, course_name: str):
         query = (
             select(models.Document.course_name,

--- a/apps/backend/ai_ta_backend/main.py
+++ b/apps/backend/ai_ta_backend/main.py
@@ -235,6 +235,38 @@ def delete(service: RetrievalService, flaskExecutor: ExecutorInterface):
   response.headers.add('Access-Control-Allow-Origin', '*')
   return response
 
+@app.route('/finalizeScrapeRun', methods=['POST'])
+def finalize_scrape_run(sql_db: SQLDatabase, service: RetrievalService, flaskExecutor: ExecutorInterface):
+  """Called by Crawlee when a (re-)scrape finishes. If delete_missing is set,
+  delete the documents linked to this scrape run whose URL was NOT seen in this
+  crawl (scoped to the run, so concurrent scrapes never delete each other's docs).
+  """
+  data = request.get_json() or {}
+  run_id = data.get('scrape_metadata_run_id')
+  course_name = data.get('course_name')
+  seen_urls = data.get('seen_urls') or []
+  delete_missing = data.get('delete_missing', False)
+
+  if not run_id or not course_name:
+    abort(400, description="scrape_metadata_run_id and course_name are required")
+
+  deleted = 0
+  if delete_missing:
+    def _norm(u):
+      return (u or '').rstrip('/')
+    seen = {_norm(u) for u in seen_urls}
+    linked = sql_db.getDocumentsForScrapeRun(run_id)
+    for doc in linked:
+      if _norm(doc.get('url')) not in seen:
+        # reuse the normal delete path (S3 + Qdrant + documents row; link cascades)
+        flaskExecutor.submit(service.delete_data, course_name, doc.get('s3_path') or '', doc.get('url') or '')
+        deleted += 1
+
+  logging.info(f"finalizeScrapeRun run={run_id} delete_missing={delete_missing} deleted={deleted}")
+  response = jsonify({"outcome": "success", "deleted_missing": deleted})
+  response.headers.add('Access-Control-Allow-Origin', '*')
+  return response
+
 @app.route('/process-chat-file', methods=['POST'])
 def process_chat_file_sync(service: RetrievalService):
     """

--- a/apps/backend/ai_ta_backend/rabbitmq/ingest.py
+++ b/apps/backend/ai_ta_backend/rabbitmq/ingest.py
@@ -185,11 +185,32 @@ class Ingest:
 
       content: str | List[str] | None = inputs.get('content', None)  # defined if ingest type is webtext
       doc_groups: List[str] | str = inputs.get('groups', '')
+      # Saved-scrape this page belongs to (web scrapes only). Used to link the
+      # resulting document to its scrape run. None for uploads / other ingests.
+      scrape_metadata_run_id = inputs.get('scrape_metadata_run_id')
+      # Re-ingest classify flags (default True => normal/new scrape ingests all).
+      update_existing = inputs.get('update_existing', True)
+      add_new = inputs.get('add_new', True)
+
+      # Classify gate (web scrapes with a run id only): skip pages we should
+      # not touch, before any embed/insert work. A page is "existing" if it
+      # was already linked to this scrape run by a previous crawl.
+      if content and scrape_metadata_run_id:
+        is_existing = self.sql_session.is_url_linked_to_run(scrape_metadata_run_id, url)
+        if is_existing and not update_existing:
+          logging.info("Skipping existing page (updateExisting=false): %s", url)
+          self.sql_session.delete_document_in_progress(job_id)
+          return json.dumps({"success_ingest": "skipped_existing", "failure_ingest": None})
+        if (not is_existing) and not add_new:
+          logging.info("Skipping new page (addNew=false): %s", url)
+          self.sql_session.delete_document_in_progress(job_id)
+          return json.dumps({"success_ingest": "skipped_new", "failure_ingest": None})
 
       print(
           f"In top of /ingest route. course: {course_name}, s3paths: {s3_paths}, readable_filename: {readable_filename}, base_url: {base_url}, url: {url}, content: {content}, doc_groups: {doc_groups}"
       )
-      success_fail_dict = self.run_ingest(course_name, s3_paths, base_url, url, readable_filename, content, doc_groups, force_embeddings)
+      success_fail_dict = self.run_ingest(course_name, s3_paths, base_url, url, readable_filename, content, doc_groups, force_embeddings,
+                                          scrape_metadata_run_id=scrape_metadata_run_id)
       # Skip retries for "no text" errors - retrying won't help
       failure_error = (success_fail_dict.get('failure_ingest', {}) or {})
       if isinstance(failure_error, dict):
@@ -236,7 +257,8 @@ class Ingest:
       success_fail_dict = {"failure_ingest": {'error': str(e)}}
       return json.dumps(success_fail_dict)
 
-  def run_ingest(self, course_name, s3_paths, base_url, url, readable_filename, content, document_groups, force_embeddings=False):
+  def run_ingest(self, course_name, s3_paths, base_url, url, readable_filename, content, document_groups, force_embeddings=False,
+                 scrape_metadata_run_id=None):
     """Routes ingest jobs based on the input data -> webscrape, url, readable_filename"""
     if content:
       return self.ingest_single_web_text(course_name,
@@ -245,7 +267,8 @@ class Ingest:
                                          content,
                                          readable_filename,
                                          groups=document_groups,
-                                         force_embeddings=force_embeddings)
+                                         force_embeddings=force_embeddings,
+                                         scrape_metadata_run_id=scrape_metadata_run_id)
     elif readable_filename == '':
       return self.bulk_ingest(course_name, s3_paths, base_url=base_url, url=url, groups=document_groups, force_embeddings=force_embeddings)
     else:
@@ -515,6 +538,16 @@ class Ingest:
       logging.info("Inserting document (size: %.2f MB)", document_size_mb)
       insert_status = self.sql_session.insert_document(document)
       if insert_status:
+        # On a web scrape, link the new document to its saved scrape run so
+        # re-crawls know which docs belong to the scrape. insert_status is
+        # the new document id. Works the same for a brand-new URL (no old
+        # docs) and a re-scrape.
+        scrape_metadata_run_id = kwargs.get('scrape_metadata_run_id')
+        if scrape_metadata_run_id:
+          self.sql_session.insert_scrape_metadata_document(
+              scrape_metadata_run_id=scrape_metadata_run_id,
+              document_id=insert_status,
+          )
         groups = kwargs.get('groups', '')
         if groups:
           if contexts[0].metadata.get('url'):

--- a/apps/backend/ai_ta_backend/rabbitmq/ingest.py
+++ b/apps/backend/ai_ta_backend/rabbitmq/ingest.py
@@ -422,6 +422,20 @@ class Ingest:
         logging.warning("No text chunks to embed (empty or whitespace-only content). Skipping upload.")
         return "Success"
 
+      # Preserve doc-group membership across an update. A re-scrape updates a
+      # page by deleting the old document row (inside check_for_duplicates
+      # below) and inserting a fresh one, which would otherwise drop the
+      # page's doc groups. Capture them now, but only when no groups were
+      # passed explicitly (web scrapes pass none; an upload with a chosen
+      # group set stays authoritative) and only for url-addressable docs.
+      incoming_groups = kwargs.get('groups', []) or []
+      preserved_doc_groups: List[str] = []
+      if not incoming_groups and metadatas[0].get('url'):
+        preserved_doc_groups = self.sql_session.get_doc_group_names_by_url(
+            metadatas[0].get('course_name'), metadatas[0].get('url'))
+        if preserved_doc_groups:
+          logging.info("Preserving doc groups across update: %s", preserved_doc_groups)
+
       # Check for duplicates (will also delete data if duplicate is found)
       is_duplicate = self.check_for_duplicates(input_texts, metadatas, force_embeddings)
       if is_duplicate and not force_embeddings:
@@ -441,7 +455,7 @@ class Ingest:
       # adding chunk index to metadata for parent doc retrieval
       for i, context in enumerate(contexts):
         context.metadata['chunk_index'] = i
-        context.metadata['doc_groups'] = kwargs.get('groups', [])
+        context.metadata['doc_groups'] = incoming_groups or preserved_doc_groups
 
       # Generate embeddings from OpenAI
       logging.info(f"Generating embeddings for {len(input_texts)} texts")
@@ -548,7 +562,10 @@ class Ingest:
               scrape_metadata_run_id=scrape_metadata_run_id,
               document_id=insert_status,
           )
-        groups = kwargs.get('groups', '')
+        # Explicitly-passed groups win; otherwise fall back to the groups
+        # preserved from the pre-update document so an updated page keeps
+        # its membership. New pages capture nothing, so they stay ungrouped.
+        groups = incoming_groups or preserved_doc_groups
         if groups:
           if contexts[0].metadata.get('url'):
             count = self.sql_session.add_document_to_group_url(contexts, groups)

--- a/apps/backend/ai_ta_backend/rabbitmq/models.py
+++ b/apps/backend/ai_ta_backend/rabbitmq/models.py
@@ -57,6 +57,15 @@ class Document(Base):
         }
 
 
+class ScrapingMetadataDocuments(Base):
+    __tablename__ = 'scraping_metadata_documents'
+    # FK + cascade are enforced by the DB (migration 0007); kept as plain columns
+    # here so the ORM mapper doesn't need a scraping_metadata_run model to resolve.
+    scrape_metadata_run_id = Column(UUID(as_uuid=True), primary_key=True)
+    document_id = Column(BigInteger, primary_key=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
 class DocumentDocGroup(Base):
     __tablename__ = 'documents_doc_groups'
     document_id = Column(BigInteger, primary_key=True)

--- a/apps/backend/ai_ta_backend/rabbitmq/rmsql.py
+++ b/apps/backend/ai_ta_backend/rabbitmq/rmsql.py
@@ -248,6 +248,29 @@ class SQLAlchemyIngestDB:
                 logging.error(f"Stored procedure execution failed: {e}")
                 return None, 0
 
+    def get_doc_group_names_by_url(self, course_name, url):
+        """Names of the doc groups the existing document at this url belongs to.
+
+        Used to preserve group membership when a re-scrape *updates* a page: the
+        old document row is deleted and a fresh one inserted (see
+        check_for_duplicates), which would otherwise drop its doc groups. We read
+        the names before the delete and re-attach them after the re-insert."""
+        with self.get_session() as session:
+            try:
+                stmt = (
+                    select(models.DocGroup.name)
+                    .join(models.DocumentDocGroup,
+                          models.DocumentDocGroup.doc_group_id == models.DocGroup.id)
+                    .join(models.Document,
+                          models.Document.id == models.DocumentDocGroup.document_id)
+                    .where(models.Document.course_name == course_name)
+                    .where(models.Document.url == url)
+                )
+                return [row[0] for row in session.execute(stmt).all()]
+            except SQLAlchemyError as e:
+                logging.error(f"get_doc_group_names_by_url failed: {e}")
+                return []
+
     def get_like_docs_by_s3_path(self, course_name, original_filename):
         query = (
             select(models.Document.id, models.Document.contexts, models.Document.s3_path)

--- a/apps/backend/ai_ta_backend/rabbitmq/rmsql.py
+++ b/apps/backend/ai_ta_backend/rabbitmq/rmsql.py
@@ -9,6 +9,7 @@ load_dotenv()
 from sqlalchemy import create_engine, NullPool, update
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import insert
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy import delete
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import text
@@ -155,15 +156,57 @@ class SQLAlchemyIngestDB:
                 logging.error(f"Deletion failed: {e}")
                 return False
 
-    def insert_document(self, doc_payload: dict) -> bool:
+    def insert_document(self, doc_payload: dict):
+        """Insert a document and return its new id (or None on failure)."""
         with self.get_session() as session:
             try:
-                insert_stmt = insert(models.Document).values(doc_payload)
-                session.execute(insert_stmt)
-                return True  # Insertion successful
+                insert_stmt = (
+                    insert(models.Document).values(doc_payload).returning(models.Document.id)
+                )
+                result = session.execute(insert_stmt)
+                return result.scalar_one()  # new document id
             except SQLAlchemyError as e:
                 logging.error(f"Insertion failed: {e}")
-                return False  # Insertion failed
+                return None  # Insertion failed
+
+    def is_url_linked_to_run(self, scrape_metadata_run_id, url) -> bool:
+        """True if a document with this url is already linked to this scrape run
+        (i.e. it existed in a previous crawl of the same saved scrape)."""
+        with self.get_session() as session:
+            try:
+                stmt = (
+                    select(models.ScrapingMetadataDocuments.document_id)
+                    .join(models.Document,
+                          models.Document.id == models.ScrapingMetadataDocuments.document_id)
+                    .where(models.ScrapingMetadataDocuments.scrape_metadata_run_id == scrape_metadata_run_id)
+                    .where(models.Document.url == url)
+                    .limit(1)
+                )
+                return session.execute(stmt).first() is not None
+            except SQLAlchemyError as e:
+                logging.error(f"is_url_linked_to_run failed: {e}")
+                return False
+
+    def insert_scrape_metadata_document(self, scrape_metadata_run_id, document_id) -> bool:
+        """Link a successfully-ingested document to the saved scrape that produced
+        it. Idempotent: a duplicate (run_id, document_id) is ignored."""
+        with self.get_session() as session:
+            try:
+                stmt = (
+                    pg_insert(models.ScrapingMetadataDocuments)
+                    .values(
+                        scrape_metadata_run_id=scrape_metadata_run_id,
+                        document_id=document_id,
+                    )
+                    .on_conflict_do_nothing(
+                        index_elements=['scrape_metadata_run_id', 'document_id']
+                    )
+                )
+                session.execute(stmt)
+                return True
+            except SQLAlchemyError as e:
+                logging.error(f"Failed to link scrape metadata document: {e}")
+                return False
 
     def add_document_to_group_url(self, contexts, groups):
         params = {

--- a/apps/crawlee/src/api/configValidation.ts
+++ b/apps/crawlee/src/api/configValidation.ts
@@ -65,6 +65,15 @@ export const configSchema = z.object({
      * @default ""
      */
     courseName: z.string(),
+    /**
+     * Saved-scrape run this crawl belongs to. Threaded into each page's /ingest
+     * body so the worker links the resulting document to the scrape run.
+     */
+    scrapeMetadataRunId: z.string().optional(),
+    /** Re-ingest flags (only meaningful on an unchanged-reuse re-ingest). */
+    deleteMissing: z.boolean().optional(),
+    updateExisting: z.boolean().optional(),
+    addNew: z.boolean().optional(),
     /** Optional cookie to be set. E.g. for Cookie Consent */
     cookie: z
         .union([

--- a/apps/crawlee/src/api/crawlee.ts
+++ b/apps/crawlee/src/api/crawlee.ts
@@ -13,6 +13,8 @@ export async function crawl(rawConfig: Config) {
 
   let pageCounter = 0;
   const ingestionPromises: Promise<any>[] = [];
+  // URLs actually crawled this run (used for the delete-missing finalize).
+  const seenUrls = new Set<string>();
   // const results: Array<{ title: string; url: string; html: string }> = [];
 
   if (config.url) {
@@ -80,6 +82,7 @@ export async function crawl(rawConfig: Config) {
 
                 // Asynchronously call the ingestWebscrape endpoint without awaiting the result
                 if (html) {
+                  if (request.loadedUrl) seenUrls.add(request.loadedUrl);
                   const ingestUrl = process.env.INGEST_URL;
 
                   if (!ingestUrl) {
@@ -103,6 +106,12 @@ export async function crawl(rawConfig: Config) {
                       content: html,
                       course_name: config.courseName,
                       groups: config.documentGroups,
+                      // Threaded to the worker so the resulting document is linked
+                      // to its saved scrape run (web scrapes only; undefined ok).
+                      scrape_metadata_run_id: config.scrapeMetadataRunId,
+                      // Re-ingest classify flags (undefined => worker defaults true).
+                      update_existing: config.updateExisting,
+                      add_new: config.addNew,
                       // s3_paths: s3Key,
                     }),
                   })
@@ -269,6 +278,32 @@ export async function crawl(rawConfig: Config) {
   }
   // Before returning from the function, wait for all the ingestion promises to resolve
   await Promise.all(ingestionPromises);
+
+  // Delete-missing finalize: report the URLs actually crawled so the backend can
+  // delete docs linked to this scrape run that no longer exist. Safe at end of
+  // crawl: missing docs weren't crawled (not being re-ingested), and seen docs
+  // are excluded from deletion.
+  if (config.scrapeMetadataRunId && config.deleteMissing) {
+    try {
+      const ingestUrl = process.env.INGEST_URL || "";
+      const finalizeUrl = ingestUrl.replace(/\/ingest\/?$/, "/finalizeScrapeRun");
+      await fetch(finalizeUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scrape_metadata_run_id: config.scrapeMetadataRunId,
+          course_name: config.courseName,
+          seen_urls: Array.from(seenUrls),
+          delete_missing: true,
+        }),
+      });
+      console.log(
+        `Finalize (delete_missing) sent for run ${config.scrapeMetadataRunId}, seen=${seenUrls.size}`,
+      );
+    } catch (e) {
+      console.error("Finalize scrape run failed:", e);
+    }
+  }
   return pageCounter;
 }
 
@@ -290,9 +325,14 @@ async function handlePdf(
 }
 function getPageHtml(page: Page, selector = "body") {
   return page.evaluate((selector) => {
-    // Exclude header, footer, nav from scraping
+    // Exclude header, footer, nav from the scraped TEXT — but HIDE them rather
+    // than remove them. innerText ignores display:none content, so the text is
+    // still excluded, while the <a> links inside nav/header/footer stay in the
+    // DOM so enqueueLinks (which runs after this) can still follow them.
     const elementsToExclude = document.querySelectorAll("header, footer, nav");
-    elementsToExclude.forEach((element) => element.remove());
+    elementsToExclude.forEach((element) => {
+      (element as HTMLElement).style.display = "none";
+    });
     // Check if the selector is an XPath
     if (selector.startsWith("/")) {
       console.log(`XPath: ${selector}`);

--- a/apps/frontend/__tests__/pages/api/__tests__/scrapeWeb.test.ts
+++ b/apps/frontend/__tests__/pages/api/__tests__/scrapeWeb.test.ts
@@ -15,6 +15,26 @@ vi.mock('axios', () => ({
   default: { post: hoisted.axiosPost },
 }))
 
+// Avoid opening a real Postgres client (dbClient connects at import). The run
+// upsert is best-effort in the handler, so a lightweight stub is enough.
+vi.mock('~/db/dbClient', () => ({
+  db: {
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: () => ({
+          returning: () => Promise.resolve([{ id: 'run-1' }]),
+        }),
+      }),
+    }),
+  },
+  scrapeMetadataRun: {
+    course_name: 'course_name',
+    url: 'url',
+    max_urls: 'max_urls',
+    scrape_strategy: 'scrape_strategy',
+  },
+}))
+
 import handler from '~/pages/api/scrapeWeb'
 
 describe('scrapeWeb API', () => {
@@ -80,6 +100,32 @@ describe('scrapeWeb API', () => {
       'http://crawlee',
       expect.any(Object),
     )
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it('strips a trailing slash so slash variants map to one scrape run', async () => {
+    process.env.CRAWLEE_API_URL = 'http://crawlee'
+    hoisted.axiosPost.mockResolvedValueOnce({ data: { ok: true } })
+
+    const res = createMockRes()
+    await handler(
+      createMockReq({
+        method: 'POST',
+        body: {
+          url: 'https://crawl-fixture.netlify.app/',
+          courseName: 'CS101',
+          maxUrls: 2,
+          scrapeStrategy: 'default',
+        },
+      }) as any,
+      res as any,
+    )
+
+    // fullUrl feeds both the stored scrape-run identity and this crawlee body,
+    // so a canonical (slash-stripped) value here means '.../' and '...' upsert
+    // into the same run row instead of creating a duplicate empty run.
+    const [, payload] = hoisted.axiosPost.mock.calls[0]
+    expect(payload.params.url).toBe('https://crawl-fixture.netlify.app')
     expect(res.status).toHaveBeenCalledWith(200)
   })
 

--- a/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
+++ b/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
@@ -405,6 +405,9 @@ export function ProjectFilesTable({
       queryClient.invalidateQueries({
         queryKey: ['documentGroups', course_name],
       })
+      // Deleting a file changes how many documents a saved scrape owns, so
+      // refresh the scrape-run list (its per-run file counts) too.
+      queryClient.invalidateQueries({ queryKey: ['scrapeRuns', course_name] })
     },
   })
 

--- a/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -71,6 +71,12 @@ const strategyLabel = (strategy: string | null | undefined) =>
 const fileCountLabel = (count: number) =>
   `${count} ${count === 1 ? 'file' : 'files'}`
 
+// Normalize a URL for equality checks: strip trailing slashes so a saved
+// scrape (the backend stores its url without one, see formatUrl in
+// scrapeWeb.ts) matches a typed URL that has one — and vice versa.
+const normalizeUrlForMatch = (url: string | null | undefined) =>
+  (url ?? '').replace(/\/+$/, '')
+
 // Secondary line for a suggestion: "Equal and Below · 50 urls · 3 files · 3 days ago"
 const scrapeRunSummary = (run: ScrapeRun) => {
   const when = run.last_run_at
@@ -303,7 +309,7 @@ export default function WebsiteIngestForm({
     () =>
       (scrapeRuns ?? []).find(
         (run) =>
-          run.url === url &&
+          normalizeUrlForMatch(run.url) === normalizeUrlForMatch(url) &&
           String(run.max_urls ?? 50) === maxUrls &&
           (run.scrape_strategy ?? 'equal-and-below') === scrapeStrategy,
       ) ?? null,
@@ -315,7 +321,7 @@ export default function WebsiteIngestForm({
     if (!urlBrowseAll) return null
     const match = (scrapeRuns ?? []).find(
       (run) =>
-        run.url === url &&
+        normalizeUrlForMatch(run.url) === normalizeUrlForMatch(url) &&
         String(run.max_urls ?? 50) === maxUrls &&
         (run.scrape_strategy ?? 'equal-and-below') === scrapeStrategy,
     )
@@ -502,6 +508,24 @@ export default function WebsiteIngestForm({
         `/api/materialsTable/successDocs?course_name=${project_name}`,
       )
       const docsData = await docsResponse.json()
+      // Strip trailing slashes so the user-entered URL and the backend-stored
+      // base_url compare equal even when one has a trailing slash and the
+      // other doesn't. Without this a "/a/" base URL never matches its
+      // completed doc, so the toast is stuck "ingesting" forever.
+      const normalizeUrl = (url: string | undefined | null) =>
+        (url ?? '').replace(/\/+$/, '')
+
+      const baseUrlMatchesFile = (
+        docBaseUrl: string,
+        file: FileUpload,
+      ): boolean => {
+        const normBase = normalizeUrl(docBaseUrl)
+        return (
+          normalizeUrl(file.name) === normBase ||
+          normalizeUrl(file.url) === normBase
+        )
+      }
+
       // Helper function to organize docs by base URL
       const organizeDocsByBaseUrl = (
         docs: Array<{ base_url: string; url: string }>,
@@ -509,10 +533,11 @@ export default function WebsiteIngestForm({
         const baseUrlMap = new Map<string, Set<string>>()
 
         docs.forEach((doc) => {
-          if (!baseUrlMap.has(doc.base_url)) {
-            baseUrlMap.set(doc.base_url, new Set())
+          const key = normalizeUrl(doc.base_url)
+          if (!baseUrlMap.has(key)) {
+            baseUrlMap.set(key, new Set())
           }
-          baseUrlMap.get(doc.base_url)?.add(doc.url)
+          baseUrlMap.get(key)?.add(doc.url)
         })
 
         return baseUrlMap
@@ -527,10 +552,8 @@ export default function WebsiteIngestForm({
           if (file.type !== 'webscrape') return file
           const fileUrl = file.url ?? ''
 
-          const isStillIngesting = docsInProgress.some(
-            (doc) =>
-              doc.base_url === file.name ||
-              (file.isBaseUrl && doc.base_url === file.url),
+          const isStillIngesting = docsInProgress.some((doc) =>
+            baseUrlMatchesFile(doc.base_url, file),
           )
 
           if (file.status === 'uploading' && isStillIngesting) {
@@ -549,8 +572,9 @@ export default function WebsiteIngestForm({
 
               const isInCompletedDocs = docsData?.documents?.some(
                 (doc: { url: string; base_url?: string }) =>
-                  doc.url === file.url ||
-                  (file.isBaseUrl && doc.base_url === file.url),
+                  normalizeUrl(doc.url) === normalizeUrl(file.url) ||
+                  (file.isBaseUrl &&
+                    normalizeUrl(doc.base_url) === normalizeUrl(file.url)),
               )
 
               if (file.isBaseUrl && allChildrenDone && isInCompletedDocs) {
@@ -569,37 +593,54 @@ export default function WebsiteIngestForm({
         })
       }
 
-      // Helper function to create new file entries for additional URLs
+      // Helper function to create new file entries for additional URLs.
+      // Includes both in-progress and already-completed docs so that URLs
+      // which finished crawling between polls still show up in the toast.
       const createAdditionalFileEntries = (
-        baseUrlMap: Map<string, Set<string>>,
+        inProgressBaseUrlMap: Map<string, Set<string>>,
+        successBaseUrlMap: Map<string, Set<string>>,
         currentFiles: FileUpload[],
-        docsInProgress: Array<{ base_url: string; readable_filename: string }>,
       ) => {
         const newFiles: FileUpload[] = []
+        const seenUrls = new Set<string>()
 
-        baseUrlMap.forEach((urls, baseUrl) => {
-          // Only process if we have this base URL in our current files
-          if (currentFiles.some((file) => file.name === baseUrl)) {
-            const matchingDoc = docsInProgress.find(
-              (doc) => doc.base_url === baseUrl,
-            )
+        const hasMatchingBaseUrl = (baseUrl: string) =>
+          currentFiles.some((file) => baseUrlMatchesFile(baseUrl, file))
 
-            const isStillIngesting = matchingDoc !== undefined
+        const alreadyTracked = (url: string) =>
+          seenUrls.has(url) ||
+          currentFiles.some(
+            (file) =>
+              normalizeUrl(file.url) === normalizeUrl(url) ||
+              normalizeUrl(file.name) === normalizeUrl(url),
+          )
 
-            urls.forEach((url) => {
-              if (
-                !currentFiles.some((file) => file.url === url) &&
-                matchingDoc
-              ) {
-                newFiles.push({
-                  name: url,
-                  status: isStillIngesting ? 'ingesting' : 'complete',
-                  type: 'webscrape',
-                  url: url,
-                })
-              }
+        inProgressBaseUrlMap.forEach((urls, baseUrl) => {
+          if (!hasMatchingBaseUrl(baseUrl)) return
+          urls.forEach((url) => {
+            if (alreadyTracked(url)) return
+            seenUrls.add(url)
+            newFiles.push({
+              name: url,
+              status: 'ingesting',
+              type: 'webscrape',
+              url: url,
             })
-          }
+          })
+        })
+
+        successBaseUrlMap.forEach((urls, baseUrl) => {
+          if (!hasMatchingBaseUrl(baseUrl)) return
+          urls.forEach((url) => {
+            if (alreadyTracked(url)) return
+            seenUrls.add(url)
+            newFiles.push({
+              name: url,
+              status: 'complete',
+              type: 'webscrape',
+              url: url,
+            })
+          })
         })
 
         return newFiles
@@ -608,15 +649,23 @@ export default function WebsiteIngestForm({
       setUploadFiles((prev) => {
         const matchingDocsInProgress =
           data?.documents?.filter((doc: { base_url: string }) =>
-            prev.some((file) => file.name === doc.base_url),
+            prev.some((file) => baseUrlMatchesFile(doc.base_url, file)),
           ) || []
 
-        const baseUrlMap = organizeDocsByBaseUrl(matchingDocsInProgress)
+        const matchingSuccessDocs =
+          docsData?.documents?.filter((doc: { base_url: string }) =>
+            prev.some((file) => baseUrlMatchesFile(doc.base_url, file)),
+          ) || []
+
+        const inProgressBaseUrlMap = organizeDocsByBaseUrl(
+          matchingDocsInProgress,
+        )
+        const successBaseUrlMap = organizeDocsByBaseUrl(matchingSuccessDocs)
 
         const additionalFiles = createAdditionalFileEntries(
-          baseUrlMap,
+          inProgressBaseUrlMap,
+          successBaseUrlMap,
           prev,
-          matchingDocsInProgress,
         )
 
         const updatedFiles = updateExistingFiles(prev, matchingDocsInProgress)

--- a/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -16,6 +16,7 @@ import {
 import { Switch } from '@/components/shadcn/ui/switch'
 import { formatDistanceToNow } from 'date-fns'
 import { useFetchScrapeRuns } from '~/hooks/queries/useFetchScrapeRuns'
+import { useDeleteScrapeRun } from '~/hooks/queries/useDeleteScrapeRun'
 import { type ScrapeRun } from '~/pages/api/scrapeRuns'
 import {
   Dialog,
@@ -32,6 +33,7 @@ import {
   IconWorld,
   IconWorldDownload,
   IconArrowRight,
+  IconTrash,
   IconInfoCircle,
   IconChevronDown,
   IconChevronUp,
@@ -87,6 +89,7 @@ interface ScrapeRunAutocompleteItem extends AutocompleteItem {
   url: string
   summary: string
   run: ScrapeRun
+  onRequestDelete: (run: ScrapeRun) => void
   highlightCurrent?: boolean
   onBrowseItemMouseEnter?: () => void
 }
@@ -97,6 +100,7 @@ const ScrapeRunAutocompleteOption = forwardRef<
     url: string
     summary: string
     run: ScrapeRun
+    onRequestDelete: (run: ScrapeRun) => void
     highlightCurrent?: boolean
     onBrowseItemMouseEnter?: () => void
   }
@@ -106,6 +110,7 @@ const ScrapeRunAutocompleteOption = forwardRef<
       url,
       summary,
       run,
+      onRequestDelete,
       highlightCurrent,
       onBrowseItemMouseEnter,
       value: _value,
@@ -146,6 +151,21 @@ const ScrapeRunAutocompleteOption = forwardRef<
           {summary}
         </Text>
       </div>
+      <ActionIcon
+        size="sm"
+        variant="subtle"
+        color="red"
+        aria-label={`Delete saved scrape ${url}`}
+        // mousedown (not click): Mantine commits a suggestion selection on
+        // mousedown, so prevent + stop it here to delete instead of pick.
+        onMouseDown={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          onRequestDelete(run)
+        }}
+      >
+        <IconTrash size={16} />
+      </ActionIcon>
     </div>
     )
   },
@@ -217,6 +237,14 @@ export default function WebsiteIngestForm({
   // Toggles the per-method explanations under "Limit web crawl" (info icon).
   const [crawlInfoOpened, setCrawlInfoOpened] = useState(false)
 
+  // The saved scrape the user is about to delete (drives the confirm overlay).
+  const [runPendingDelete, setRunPendingDelete] = useState<ScrapeRun | null>(
+    null,
+  )
+  // When true, confirming the delete also removes the documents this scrape
+  // produced (not just the saved parameters). Reset whenever the overlay opens
+  // or closes — see the effect below.
+  const [deleteFilesWithRun, setDeleteFilesWithRun] = useState(false)
   const urlInputRef = useRef<HTMLInputElement>(null)
   const [urlDropdownOpened, setUrlDropdownOpened] = useState(false)
   // When true, the URL dropdown lists every saved scrape (not filtered by the
@@ -231,8 +259,22 @@ export default function WebsiteIngestForm({
     setUrlBrowseHighlightSuppressed(false)
   }
 
+  // Open the confirm overlay and close the autocomplete dropdown (blur the
+  // input) so the dropdown isn't left open behind the confirmation.
+  const requestDelete = (run: ScrapeRun) => {
+    setRunPendingDelete(run)
+    urlInputRef.current?.blur()
+  }
+
+  // Every time the confirm overlay is shown or hidden, start from the safe
+  // default (files kept) so a prior "on" never carries into the next delete.
+  useEffect(() => {
+    setDeleteFilesWithRun(false)
+  }, [runPendingDelete])
+
   // Previous scrape parameter sets for this project (most-recently-used first).
   const { data: scrapeRuns } = useFetchScrapeRuns({ courseName: project_name })
+  const deleteScrapeRun = useDeleteScrapeRun({ courseName: project_name })
 
   // One suggestion per distinct param set; `value` unique to avoid key clashes.
   const scrapeRunSuggestions: ScrapeRunAutocompleteItem[] = useMemo(
@@ -242,6 +284,7 @@ export default function WebsiteIngestForm({
         url: run.url,
         summary: scrapeRunSummary(run),
         run,
+        onRequestDelete: requestDelete,
       })),
     [scrapeRuns],
   )
@@ -318,6 +361,29 @@ export default function WebsiteIngestForm({
     highlightedScrapeRunId,
     scrapeRunAutocompleteData,
   ])
+
+  const handleConfirmDelete = () => {
+    if (!runPendingDelete) return
+    deleteScrapeRun.mutate(
+      { id: runPendingDelete.id, deleteFiles: deleteFilesWithRun },
+      {
+        onSuccess: () => setRunPendingDelete(null),
+        onError: () => {
+          notifications.show({
+            title: (
+              <Text size={'lg'} className={`${montserrat_med.className}`}>
+                Failed to delete saved scrape
+              </Text>
+            ),
+            message: deleteFilesWithRun
+              ? 'Some files could not be deleted. The saved scrape was kept. Please try again.'
+              : 'Please try again.',
+            color: 'red',
+          })
+        },
+      },
+    )
+  }
 
   const setUrlValue = (input: string) => {
     setUrl(input)
@@ -1118,6 +1184,68 @@ export default function WebsiteIngestForm({
               {isReingest ? 'Re-ingest the Website' : 'Ingest the Website'}
             </Button>
           </div>
+
+          {/* Confirm deleting a saved scrape. Rendered INSIDE the ingest dialog
+              (a DOM descendant) so confirming/cancelling never closes the
+              ingest window. Also the seam for a future "also delete the scraped
+              pages" option. */}
+          {runPendingDelete && (
+            <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+              <div
+                className="absolute inset-0 bg-black/60"
+                onClick={() => setRunPendingDelete(null)}
+                aria-hidden="true"
+              />
+              <div className="relative z-10 w-full max-w-md rounded-md bg-[--modal] p-6 text-[--modal-text] shadow-xl">
+                <Text
+                  className={`${montserrat_heading.variable} mb-3 font-montserratHeading`}
+                  style={{ fontSize: '18px', fontWeight: 700 }}
+                >
+                  Delete this saved scrape?
+                </Text>
+                <Text size="sm" truncate>
+                  {runPendingDelete.url}
+                </Text>
+                <Text size="xs" opacity={0.6}>
+                  {scrapeRunSummary(runPendingDelete)}
+                </Text>
+                <Text size="sm" className="mt-4">
+                  {deleteFilesWithRun
+                    ? 'This removes the saved parameters and permanently deletes the pages this scrape created from your project.'
+                    : 'This removes the saved parameters from your suggestions. It does not delete any pages already scraped from this URL.'}
+                </Text>
+                <div className="mt-4">
+                  <Switch
+                    variant="labeled"
+                    showLabels
+                    showThumbIcon
+                    size="sm"
+                    label="Also delete the files this scrape created"
+                    checked={deleteFilesWithRun}
+                    onCheckedChange={(checked) =>
+                      setDeleteFilesWithRun(checked)
+                    }
+                  />
+                </div>
+                <div className="mt-5 flex justify-end">
+                  <Button
+                    onClick={() => setRunPendingDelete(null)}
+                    disabled={deleteScrapeRun.isPending}
+                    className="mr-[7px] min-w-[3rem] rounded-s-md bg-[--background-faded] text-[--foreground] hover:bg-[--dashboard-button-hover] hover:text-[--dashboard-button-foreground] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[--dashboard-button]"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleConfirmDelete}
+                    loading={deleteScrapeRun.isPending}
+                    className="min-w-[3rem] rounded-s-md bg-[--dashboard-button] text-[--dashboard-button-foreground] hover:bg-[--dashboard-button-hover] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[--dashboard-button]"
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     </motion.div>

--- a/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -13,6 +13,7 @@ import {
   Center,
   rem,
 } from '@mantine/core'
+import { Switch } from '@/components/shadcn/ui/switch'
 import { formatDistanceToNow } from 'date-fns'
 import { useFetchScrapeRuns } from '~/hooks/queries/useFetchScrapeRuns'
 import { type ScrapeRun } from '~/pages/api/scrapeRuns'
@@ -208,6 +209,11 @@ export default function WebsiteIngestForm({
   const [scrapeStrategy, setScrapeStrategy] =
     useState<string>('equal-and-below')
   const [open, setOpen] = useState(false)
+  // Re-ingest options — shown only when the form exactly matches a saved scrape
+  // (an unchanged reuse). Editing any field breaks the match and hides them.
+  const [deleteMissing, setDeleteMissing] = useState(false)
+  const [updateExisting, setUpdateExisting] = useState(true)
+  const [addNew, setAddNew] = useState(true)
   // Toggles the per-method explanations under "Limit web crawl" (info icon).
   const [crawlInfoOpened, setCrawlInfoOpened] = useState(false)
 
@@ -241,6 +247,21 @@ export default function WebsiteIngestForm({
   )
 
   const hasScrapeHistory = scrapeRunSuggestions.length > 0
+
+  // The saved scrape the current form values exactly reproduce, if any. Present
+  // => the user reused a previous scrape and changed nothing => "re-ingest" mode
+  // (button label + the three re-ingest toggles). Any edit breaks the match.
+  const matchedReuseRun = useMemo(
+    () =>
+      (scrapeRuns ?? []).find(
+        (run) =>
+          run.url === url &&
+          String(run.max_urls ?? 50) === maxUrls &&
+          (run.scrape_strategy ?? 'equal-and-below') === scrapeStrategy,
+      ) ?? null,
+    [scrapeRuns, url, maxUrls, scrapeStrategy],
+  )
+  const isReingest = matchedReuseRun !== null && isUrlValid
 
   const highlightedScrapeRunId = useMemo(() => {
     if (!urlBrowseAll) return null
@@ -358,6 +379,7 @@ export default function WebsiteIngestForm({
           project_name,
           maxUrls.trim() !== '' ? parseInt(maxUrls) : 50,
           scrapeStrategy,
+          isReingest ? { deleteMissing, updateExisting, addNew } : undefined,
         )
         // Refresh the URL autocomplete suggestions with this run's params.
         await queryClient.invalidateQueries({
@@ -547,6 +569,11 @@ export default function WebsiteIngestForm({
     courseName: string | null,
     maxUrls: number,
     scrapeStrategy: string,
+    reingestOptions?: {
+      deleteMissing: boolean
+      updateExisting: boolean
+      addNew: boolean
+    },
   ) => {
     try {
       if (!url || !courseName) return null
@@ -557,6 +584,9 @@ export default function WebsiteIngestForm({
         courseName,
         maxUrls,
         scrapeStrategy,
+        // Only sent on an unchanged-reuse re-ingest; the backend wires these up
+        // separately. Harmless for a normal/new ingest (omitted).
+        ...(reingestOptions ?? {}),
       })
 
       console.log(
@@ -614,6 +644,9 @@ export default function WebsiteIngestForm({
             setUrlDropdownOpened(false)
             setUrlBrowseAll(false)
             setUrlBrowseHighlightSuppressed(false)
+            setDeleteMissing(false)
+            setUpdateExisting(true)
+            setAddNew(true)
             setInputErrors((prev) => ({
               ...prev,
               maxUrls: { error: false, message: '' },
@@ -1036,12 +1069,53 @@ export default function WebsiteIngestForm({
             </div>
           </div>
           <div className="mt-4">
+            {/* Re-ingest options: only when the form exactly matches a saved
+                scrape (unchanged reuse). Editing any field hides these. */}
+            {isReingest && (
+              <div className="mb-3 rounded-xl border border-[--background-dark] bg-[--background-faded] p-3">
+                <Text
+                  style={{ fontSize: '14px' }}
+                  className={`${montserrat_heading.variable} mb-2 font-montserratHeading text-[--modal-text]`}
+                >
+                  Re-ingest options
+                </Text>
+                <div className="flex flex-col gap-2">
+                  <Switch
+                    variant="labeled"
+                    showLabels
+                    showThumbIcon
+                    size="sm"
+                    label="Add newly found pages"
+                    checked={addNew}
+                    onCheckedChange={(checked) => setAddNew(checked)}
+                  />
+                  <Switch
+                    variant="labeled"
+                    showLabels
+                    showThumbIcon
+                    size="sm"
+                    label="Update pages that changed"
+                    checked={updateExisting}
+                    onCheckedChange={(checked) => setUpdateExisting(checked)}
+                  />
+                  <Switch
+                    variant="labeled"
+                    showLabels
+                    showThumbIcon
+                    size="sm"
+                    label="Delete pages no longer found"
+                    checked={deleteMissing}
+                    onCheckedChange={(checked) => setDeleteMissing(checked)}
+                  />
+                </div>
+              </div>
+            )}
             <Button
               onClick={handleIngest}
               disabled={!isUrlValid}
               className="h-11 w-full rounded-xl bg-[--dashboard-button] text-[--dashboard-button-foreground] transition-colors hover:bg-[--dashboard-button-hover] disabled:bg-[--background-faded] disabled:text-[--background-dark]"
             >
-              Ingest the Website
+              {isReingest ? 'Re-ingest the Website' : 'Ingest the Website'}
             </Button>
           </div>
         </DialogContent>

--- a/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -1,16 +1,21 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { forwardRef, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Text,
   Card,
   Tooltip,
   Button,
-  Input,
+  Autocomplete,
+  type AutocompleteItem,
+  ActionIcon,
   TextInput,
   List,
   SegmentedControl,
   Center,
   rem,
 } from '@mantine/core'
+import { formatDistanceToNow } from 'date-fns'
+import { useFetchScrapeRuns } from '~/hooks/queries/useFetchScrapeRuns'
+import { type ScrapeRun } from '~/pages/api/scrapeRuns'
 import {
   Dialog,
   DialogContent,
@@ -26,10 +31,13 @@ import {
   IconWorld,
   IconWorldDownload,
   IconArrowRight,
+  IconInfoCircle,
+  IconChevronDown,
+  IconChevronUp,
 } from '@tabler/icons-react'
 // import { APIKeyInput } from '../LLMsApiKeyInputForm'
 // import { ModelToggles } from '../ModelToggles'
-import { motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 // import { Checkbox } from '@radix-ui/react-checkbox'
 import { montserrat_heading } from 'fonts'
 import { notifications } from '@mantine/notifications'
@@ -42,6 +50,107 @@ const montserrat_med = Montserrat({
   weight: '500',
   subsets: ['latin'],
 })
+
+// Human-readable labels for the scrape strategy values used by SegmentedControl.
+const SCRAPE_STRATEGY_LABELS: Record<string, string> = {
+  'equal-and-below': 'Equal and Below',
+  'same-hostname': 'Subdomain',
+  'same-domain': 'Entire domain',
+  all: 'All',
+}
+
+const strategyLabel = (strategy: string | null | undefined) =>
+  (strategy && SCRAPE_STRATEGY_LABELS[strategy]) ||
+  strategy ||
+  'Equal and Below'
+
+// Secondary line for a suggestion: "Equal and Below · 50 urls · 3 days ago"
+const scrapeRunSummary = (run: ScrapeRun) => {
+  const when = run.last_run_at
+    ? formatDistanceToNow(new Date(run.last_run_at), { addSuffix: true })
+    : ''
+  return [
+    strategyLabel(run.scrape_strategy),
+    `${run.max_urls ?? 50} urls`,
+    when,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+}
+
+// Each Autocomplete suggestion carries the underlying run so onItemSubmit can
+// apply its exact params. `value` is unique (url + id) to keep React keys clean
+// when the same URL has several param sets; the input is corrected back to the
+// bare URL on select (see handleSuggestionSubmit).
+interface ScrapeRunAutocompleteItem extends AutocompleteItem {
+  url: string
+  summary: string
+  run: ScrapeRun
+  highlightCurrent?: boolean
+  onBrowseItemMouseEnter?: () => void
+}
+
+const ScrapeRunAutocompleteOption = forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<'div'> & {
+    url: string
+    summary: string
+    run: ScrapeRun
+    highlightCurrent?: boolean
+    onBrowseItemMouseEnter?: () => void
+  }
+>(
+  (
+    {
+      url,
+      summary,
+      run,
+      highlightCurrent,
+      onBrowseItemMouseEnter,
+      value: _value,
+      onMouseEnter: mantineOnMouseEnter,
+      ...others
+    }: any,
+    ref,
+  ) => {
+    const mantineHovered = others['data-hovered']
+
+    return (
+      <div
+        ref={ref}
+        {...others}
+        onMouseEnter={(e) => {
+          mantineOnMouseEnter?.(e)
+          onBrowseItemMouseEnter?.()
+        }}
+        data-hovered={(mantineHovered || highlightCurrent) || undefined}
+        style={{
+          ...others.style,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          ...(highlightCurrent && !mantineHovered
+            ? {
+                color: 'var(--foreground)',
+                backgroundColor: 'var(--foreground-faded)',
+              }
+            : {}),
+        }}
+      >
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <Text size="sm" truncate>
+          {url}
+        </Text>
+        <Text size="xs" opacity={0.6} truncate>
+          {summary}
+        </Text>
+      </div>
+    </div>
+    )
+  },
+)
+ScrapeRunAutocompleteOption.displayName = 'ScrapeRunAutocompleteOption'
+
 export default function WebsiteIngestForm({
   project_name,
   setUploadFiles,
@@ -99,11 +208,116 @@ export default function WebsiteIngestForm({
   const [scrapeStrategy, setScrapeStrategy] =
     useState<string>('equal-and-below')
   const [open, setOpen] = useState(false)
-  const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const input = e.target.value
+  // Toggles the per-method explanations under "Limit web crawl" (info icon).
+  const [crawlInfoOpened, setCrawlInfoOpened] = useState(false)
+
+  const urlInputRef = useRef<HTMLInputElement>(null)
+  const [urlDropdownOpened, setUrlDropdownOpened] = useState(false)
+  // When true, the URL dropdown lists every saved scrape (not filtered by the
+  // current input). Typing switches back to search mode.
+  const [urlBrowseAll, setUrlBrowseAll] = useState(false)
+  // Clears the default "current selection" highlight once the user hovers any item.
+  const [urlBrowseHighlightSuppressed, setUrlBrowseHighlightSuppressed] =
+    useState(false)
+
+  const enterUrlBrowseMode = () => {
+    setUrlBrowseAll(true)
+    setUrlBrowseHighlightSuppressed(false)
+  }
+
+  // Previous scrape parameter sets for this project (most-recently-used first).
+  const { data: scrapeRuns } = useFetchScrapeRuns({ courseName: project_name })
+
+  // One suggestion per distinct param set; `value` unique to avoid key clashes.
+  const scrapeRunSuggestions: ScrapeRunAutocompleteItem[] = useMemo(
+    () =>
+      (scrapeRuns ?? []).map((run) => ({
+        value: `${run.url} ${run.id}`,
+        url: run.url,
+        summary: scrapeRunSummary(run),
+        run,
+      })),
+    [scrapeRuns],
+  )
+
+  const hasScrapeHistory = scrapeRunSuggestions.length > 0
+
+  const highlightedScrapeRunId = useMemo(() => {
+    if (!urlBrowseAll) return null
+    const match = (scrapeRuns ?? []).find(
+      (run) =>
+        run.url === url &&
+        String(run.max_urls ?? 50) === maxUrls &&
+        (run.scrape_strategy ?? 'equal-and-below') === scrapeStrategy,
+    )
+    return match?.id ?? null
+  }, [urlBrowseAll, scrapeRuns, url, maxUrls, scrapeStrategy])
+
+  const scrapeRunAutocompleteData: ScrapeRunAutocompleteItem[] = useMemo(
+    () =>
+      scrapeRunSuggestions.map((item) => ({
+        ...item,
+        highlightCurrent:
+          urlBrowseAll &&
+          !urlBrowseHighlightSuppressed &&
+          item.run.id === highlightedScrapeRunId,
+        onBrowseItemMouseEnter: () => setUrlBrowseHighlightSuppressed(true),
+      })),
+    [
+      scrapeRunSuggestions,
+      urlBrowseAll,
+      urlBrowseHighlightSuppressed,
+      highlightedScrapeRunId,
+    ],
+  )
+
+  const openUrlBrowseDropdown = () => {
+    if (!hasScrapeHistory) return
+    enterUrlBrowseMode()
+    urlInputRef.current?.focus()
+    urlInputRef.current?.click()
+  }
+
+  useEffect(() => {
+    if (!urlBrowseAll || !urlDropdownOpened || !highlightedScrapeRunId) return
+    const index = scrapeRunAutocompleteData.findIndex(
+      (item) => item.run.id === highlightedScrapeRunId,
+    )
+    if (index < 0) return
+    const inputId = urlInputRef.current?.id
+    if (!inputId) return
+    requestAnimationFrame(() => {
+      document
+        .getElementById(`${inputId}-${index}`)
+        ?.scrollIntoView({ block: 'nearest' })
+    })
+  }, [
+    urlBrowseAll,
+    urlDropdownOpened,
+    highlightedScrapeRunId,
+    scrapeRunAutocompleteData,
+  ])
+
+  const setUrlValue = (input: string) => {
     setUrl(input)
     setIsUrlValid(validateUrl(input))
   }
+
+  // Picking a suggestion auto-applies its params and resets the input to the
+  // bare URL (overriding the unique `value` Mantine just committed). Both
+  // setState calls batch within this handler, so the composite never renders.
+  const handleSuggestionSubmit = (item: AutocompleteItem) => {
+    const run = (item as ScrapeRunAutocompleteItem).run
+    if (!run) return
+    setUrlValue(run.url)
+    setMaxUrls(String(run.max_urls ?? 50))
+    setScrapeStrategy(run.scrape_strategy ?? 'equal-and-below')
+    setInputErrors((prev) => ({
+      ...prev,
+      maxUrls: { error: false, message: '' },
+    }))
+  }
+
   const validateUrl = (input: string) => {
     const regex = /^(https?:\/\/)?.+/
     return regex.test(input)
@@ -145,6 +359,10 @@ export default function WebsiteIngestForm({
           maxUrls.trim() !== '' ? parseInt(maxUrls) : 50,
           scrapeStrategy,
         )
+        // Refresh the URL autocomplete suggestions with this run's params.
+        await queryClient.invalidateQueries({
+          queryKey: ['scrapeRuns', project_name],
+        })
         // Transition to 'ingesting' status after API call succeeds
         setUploadFiles((prevFiles) =>
           prevFiles.map((file) =>
@@ -393,6 +611,9 @@ export default function WebsiteIngestForm({
             setIsUrlValid(false)
             setIsUrlUpdated(false)
             setMaxUrls('50')
+            setUrlDropdownOpened(false)
+            setUrlBrowseAll(false)
+            setUrlBrowseHighlightSuppressed(false)
             setInputErrors((prev) => ({
               ...prev,
               maxUrls: { error: false, message: '' },
@@ -458,11 +679,80 @@ export default function WebsiteIngestForm({
                     event.preventDefault()
                   }}
                 >
-                  <Input
+                  <Autocomplete
+                    ref={urlInputRef}
                     icon={icon}
+                    rightSection={
+                      hasScrapeHistory ? (
+                        <button
+                          type="button"
+                          aria-label={
+                            urlDropdownOpened
+                              ? 'Hide saved scrapes'
+                              : 'Show saved scrapes'
+                          }
+                          aria-expanded={urlDropdownOpened}
+                          tabIndex={-1}
+                          className="flex h-full items-center justify-center border-0 bg-transparent p-0 text-[--foreground] hover:text-[--illinois-orange]"
+                          onMouseDown={(e) => {
+                            e.preventDefault()
+                            if (urlDropdownOpened) {
+                              urlInputRef.current?.blur()
+                            } else {
+                              openUrlBrowseDropdown()
+                            }
+                          }}
+                        >
+                          {urlDropdownOpened ? (
+                            <IconChevronUp
+                              size={18}
+                              stroke={2}
+                              aria-hidden="true"
+                            />
+                          ) : (
+                            <IconChevronDown
+                              size={18}
+                              stroke={2}
+                              aria-hidden="true"
+                            />
+                          )}
+                        </button>
+                      ) : null
+                    }
+                    rightSectionWidth={hasScrapeHistory ? rem(40) : undefined}
+                    onDropdownOpen={() => setUrlDropdownOpened(true)}
+                    onDropdownClose={() => {
+                      setUrlDropdownOpened(false)
+                      setUrlBrowseAll(false)
+                      setUrlBrowseHighlightSuppressed(false)
+                    }}
+                    onFocus={() => {
+                      if (hasScrapeHistory) enterUrlBrowseMode()
+                    }}
+                    onClick={() => {
+                      if (hasScrapeHistory) enterUrlBrowseMode()
+                    }}
                     aria-label="Website URL"
                     className="w-full rounded-full"
-                    styles={{
+                    data={scrapeRunAutocompleteData}
+                    itemComponent={ScrapeRunAutocompleteOption}
+                    onItemSubmit={handleSuggestionSubmit}
+                    limit={50}
+                    maxDropdownHeight={280}
+                    // Suggest by URL match (and the summary), not the unique value.
+                    filter={(query, item) => {
+                      const it = item as ScrapeRunAutocompleteItem
+                      if (urlBrowseAll) return true
+                      const q = query.toLowerCase().trim()
+                      return (
+                        it.url.toLowerCase().includes(q) ||
+                        it.summary.toLowerCase().includes(q)
+                      )
+                    }}
+                    nothingFound={null}
+                    // Dropdown colors + hover match the default-model Select on
+                    // the LLMs admin page (see api-inputs/LLMsApiKeyInputForm.tsx).
+                    styles={(theme) => ({
                       input: {
                         color: 'var(--foreground)',
                         backgroundColor: 'var(--background-faded)',
@@ -477,14 +767,46 @@ export default function WebsiteIngestForm({
                       wrapper: {
                         width: '100%',
                       },
-                    }}
+                      rightSection: {
+                        pointerEvents: 'auto',
+                        color: 'var(--foreground)',
+                      },
+                      dropdown: {
+                        backgroundColor: 'var(--background)',
+                        border: '1px solid var(--background-dark)',
+                        borderRadius: theme.radius.md,
+                        marginTop: '2px',
+                        boxShadow: theme.shadows.xs,
+                      },
+                      item: {
+                        color: 'var(--foreground)',
+                        backgroundColor: 'var(--background)',
+                        borderRadius: theme.radius.md,
+                        margin: '2px',
+                        overflow: 'hidden',
+                        '&[data-hovered]': {
+                          color: 'var(--foreground)',
+                          backgroundColor: 'var(--foreground-faded)',
+                        },
+                        '&[data-selected]': {
+                          '&': {
+                            color: 'var(--foreground)',
+                            backgroundColor: 'transparent',
+                          },
+                          '&:hover': {
+                            color: 'var(--foreground)',
+                            backgroundColor: 'var(--foreground-faded)',
+                          },
+                        },
+                      },
+                    })}
                     placeholder="Enter URL..."
                     radius="md"
-                    type="url"
                     value={url}
                     size="lg"
-                    onChange={(e) => {
-                      handleUrlChange(e)
+                    onChange={(value) => {
+                      setUrlBrowseAll(false)
+                      setUrlValue(value)
                     }}
                   />
                   <div className="pb-2 pt-2">
@@ -557,14 +879,39 @@ export default function WebsiteIngestForm({
                     </p>
                   )}
 
-                  <Text
-                    style={{ fontSize: '16px' }}
-                    className={`${montserrat_heading.variable} mt-4 font-montserratHeading`}
-                  >
-                    Limit web crawl
-                  </Text>
-                  <div className="mt-2 pl-3">
-                    <List className="text-[--modal-text]">
+                  <div className="mt-4 flex items-center gap-2">
+                    <Text
+                      style={{ fontSize: '16px' }}
+                      className={`${montserrat_heading.variable} font-montserratHeading`}
+                    >
+                      Limit web crawl
+                    </Text>
+                    <ActionIcon
+                      variant="subtle"
+                      color="var(--foreground-faded)"
+                      onClick={() => setCrawlInfoOpened(!crawlInfoOpened)}
+                      className="hover:bg-[--background]"
+                      title="What does each crawl limit mean?"
+                    >
+                      <IconInfoCircle
+                        className="text-[--foreground-faded] hover:text-[--foreground]"
+                        aria-hidden="true"
+                      />
+                    </ActionIcon>
+                  </div>
+                  <AnimatePresence>
+                    {crawlInfoOpened && (
+                      <motion.div
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: 'auto' }}
+                        exit={{ opacity: 0, height: 0 }}
+                        transition={{ duration: 0.2, ease: 'easeInOut' }}
+                        className="mt-2 overflow-hidden"
+                      >
+                        <div className="flex bg-[--background-faded]">
+                          <div className="w-1 bg-[--illinois-orange]" />
+                          <div className="flex-1 p-4">
+                            <List className="text-[--modal-text]">
                       <List.Item>
                         <strong>Equal and Below:</strong> Only scrape content
                         that starts will the given URL. E.g. nasa.gov/blogs will
@@ -599,13 +946,18 @@ export default function WebsiteIngestForm({
                           </Text>
                         </span>
                       </List.Item>
-                    </List>
-                  </div>
-
-                  <Text className="mt-4">
-                    <strong>I suggest starting with Equal and Below</strong>,
-                    then just re-run this if you need more later.
-                  </Text>
+                            </List>
+                            <Text className="mt-4 text-[--modal-text]">
+                              <strong>
+                                I suggest starting with Equal and Below
+                              </strong>
+                              , then just re-run this if you need more later.
+                            </Text>
+                          </div>
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
 
                   <SegmentedControl
                     fullWidth

--- a/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -67,7 +67,11 @@ const strategyLabel = (strategy: string | null | undefined) =>
   strategy ||
   'Equal and Below'
 
-// Secondary line for a suggestion: "Equal and Below · 50 urls · 3 days ago"
+// "3 files" / "1 file" / "0 files"
+const fileCountLabel = (count: number) =>
+  `${count} ${count === 1 ? 'file' : 'files'}`
+
+// Secondary line for a suggestion: "Equal and Below · 50 urls · 3 files · 3 days ago"
 const scrapeRunSummary = (run: ScrapeRun) => {
   const when = run.last_run_at
     ? formatDistanceToNow(new Date(run.last_run_at), { addSuffix: true })
@@ -75,6 +79,7 @@ const scrapeRunSummary = (run: ScrapeRun) => {
   return [
     strategyLabel(run.scrape_strategy),
     `${run.max_urls ?? 50} urls`,
+    fileCountLabel(run.document_count ?? 0),
     when,
   ]
     .filter(Boolean)
@@ -1220,7 +1225,9 @@ export default function WebsiteIngestForm({
                     showLabels
                     showThumbIcon
                     size="sm"
-                    label="Also delete the files this scrape created"
+                    label={`Also delete the ${fileCountLabel(
+                      runPendingDelete.document_count ?? 0,
+                    )} this scrape created`}
                     checked={deleteFilesWithRun}
                     onCheckedChange={(checked) =>
                       setDeleteFilesWithRun(checked)

--- a/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
@@ -281,4 +281,69 @@ describe('WebsiteIngestForm', () => {
       expect(filesJson).toContain('"status":"error"')
     })
   })
+
+  it('sends delete_files=true only when the delete-files toggle is on', async () => {
+    const run = {
+      id: 'run-1',
+      course_name: 'CS101',
+      url: 'https://example.com',
+      max_urls: 50,
+      scrape_strategy: 'equal-and-below',
+      created_at: '2026-06-01T00:00:00.000Z',
+      last_run_at: '2026-06-01T00:00:00.000Z',
+    }
+    let deleteUrl = ''
+    server.use(
+      http.get('*/api/scrapeRuns*', async () =>
+        HttpResponse.json({ runs: [run] }),
+      ),
+      http.delete('*/api/scrapeRuns*', async ({ request }) => {
+        deleteUrl = request.url
+        return HttpResponse.json({ success: true })
+      }),
+    )
+
+    const user = userEvent.setup()
+    const queryClient = createTestQueryClient()
+    const { default: WebsiteIngestForm } = await import('../WebsiteIngestForm')
+    renderWithProviders(
+      <WebsiteIngestForm
+        project_name="CS101"
+        setUploadFiles={vi.fn() as any}
+        queryClient={queryClient}
+      />,
+      { homeContext: { dispatch: vi.fn() }, queryClient },
+    )
+
+    // Open the ingest dialog (the trigger reads "Configure import").
+    await user.click(screen.getByText(/Configure import/i))
+
+    // Focus the URL field so the saved-run dropdown (and its delete trash icon)
+    // renders in browse-all mode.
+    const urlInput = screen.getAllByPlaceholderText('Enter URL...')[0]!
+    await user.click(urlInput)
+
+    // Request deletion of the saved run -> confirm overlay appears.
+    const deleteRunBtn = await screen.findByLabelText(
+      /delete saved scrape https:\/\/example\.com/i,
+    )
+    await user.click(deleteRunBtn)
+
+    // The overlay's copy and toggle are present; toggle defaults OFF. The
+    // shadcn Switch renders a Radix element with role="switch" (its label is a
+    // sibling span, so query by role rather than label text).
+    expect(
+      await screen.findByText(/also delete the files this scrape created/i),
+    ).toBeInTheDocument()
+    const toggle = screen.getByRole('switch')
+    expect(toggle).not.toBeChecked()
+
+    // Turn it on and confirm.
+    await user.click(toggle)
+    await user.click(screen.getByRole('button', { name: /^delete$/i }))
+
+    await waitFor(() => expect(deleteUrl).toContain('/api/scrapeRuns'))
+    expect(deleteUrl).toContain('delete_files=true')
+    expect(deleteUrl).toContain('id=run-1')
+  })
 })

--- a/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
@@ -291,6 +291,7 @@ describe('WebsiteIngestForm', () => {
       scrape_strategy: 'equal-and-below',
       created_at: '2026-06-01T00:00:00.000Z',
       last_run_at: '2026-06-01T00:00:00.000Z',
+      document_count: 3,
     }
     let deleteUrl = ''
     server.use(
@@ -333,7 +334,7 @@ describe('WebsiteIngestForm', () => {
     // shadcn Switch renders a Radix element with role="switch" (its label is a
     // sibling span, so query by role rather than label text).
     expect(
-      await screen.findByText(/also delete the files this scrape created/i),
+      await screen.findByText(/also delete the 3 files this scrape created/i),
     ).toBeInTheDocument()
     const toggle = screen.getByRole('switch')
     expect(toggle).not.toBeChecked()

--- a/apps/frontend/src/db/migrations/0006_kind_lady_deathstrike.sql
+++ b/apps/frontend/src/db/migrations/0006_kind_lady_deathstrike.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "scraping_metadata_run" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"course_name" text NOT NULL,
+	"url" text NOT NULL,
+	"max_urls" integer DEFAULT 50,
+	"scrape_strategy" text DEFAULT 'equal-and-below',
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_run_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "scraping_metadata_run_course_url_params_key" ON "scraping_metadata_run" USING btree ("course_name","url","max_urls","scrape_strategy");

--- a/apps/frontend/src/db/migrations/0007_lush_paladin.sql
+++ b/apps/frontend/src/db/migrations/0007_lush_paladin.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "scraping_metadata_documents" (
+	"scrape_metadata_run_id" uuid NOT NULL,
+	"document_id" bigint NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "scraping_metadata_documents_scrape_metadata_run_id_document_id_pk" PRIMARY KEY("scrape_metadata_run_id","document_id")
+);
+--> statement-breakpoint
+ALTER TABLE "scraping_metadata_documents" ADD CONSTRAINT "scraping_metadata_documents_scrape_metadata_run_id_scraping_metadata_run_id_fk" FOREIGN KEY ("scrape_metadata_run_id") REFERENCES "public"."scraping_metadata_run"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "scraping_metadata_documents" ADD CONSTRAINT "scraping_metadata_documents_document_id_documents_id_fk" FOREIGN KEY ("document_id") REFERENCES "public"."documents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "scraping_metadata_documents_document_id_idx" ON "scraping_metadata_documents" USING btree ("document_id");

--- a/apps/frontend/src/db/migrations/meta/0006_snapshot.json
+++ b/apps/frontend/src/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,2193 @@
+{
+  "id": "9a64c243-9662-4ce0-84c2-26a1b9937e42",
+  "prevId": "be5651b6-4094-4b8a-a3c8-603e73b5745f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keycloak_id": {
+          "name": "keycloak_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cedar_chunks": {
+      "name": "cedar_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_id": {
+          "name": "embedding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cedar_document_metadata": {
+      "name": "cedar_document_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cedar_documents": {
+      "name": "cedar_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_source": {
+          "name": "document_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_groups": {
+          "name": "doc_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cedar_runs": {
+      "name": "cedar_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_names": {
+      "name": "course_names",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_groups": {
+      "name": "doc_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "doc_count": {
+          "name": "doc_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "doc_groups_name_course_unique": {
+          "name": "doc_groups_name_course_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_groups_sharing": {
+      "name": "doc_groups_sharing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doc_group_id": {
+          "name": "doc_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_email": {
+          "name": "shared_with_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_level": {
+          "name": "permission_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "s3_path": {
+          "name": "s3_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "readable_filename": {
+          "name": "readable_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents_doc_groups": {
+      "name": "documents_doc_groups",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_group_id": {
+          "name": "doc_group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_doc_groups_pkey": {
+          "name": "documents_doc_groups_pkey",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doc_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents_failed": {
+      "name": "documents_failed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "s3_path": {
+          "name": "s3_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readable_filename": {
+          "name": "readable_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_groups": {
+          "name": "doc_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents_in_progress": {
+      "name": "documents_in_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "s3_path": {
+          "name": "s3_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readable_filename": {
+          "name": "readable_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_groups": {
+          "name": "doc_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beam_task_id": {
+          "name": "beam_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email-newsletter": {
+      "name": "email-newsletter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed-from-newsletter": {
+          "name": "unsubscribed-from-newsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_uploads": {
+      "name": "file_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readable_filename": {
+          "name": "readable_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_path": {
+          "name": "s3_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_entity": {
+      "name": "user_entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_constraint": {
+          "name": "email_constraint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "federation_link": {
+          "name": "federation_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_timestamp": {
+          "name": "created_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_account_client_link": {
+          "name": "service_account_client_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_before": {
+          "name": "not_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm-convo-monitor": {
+      "name": "llm-convo-monitor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "convo": {
+          "name": "convo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "convo_id": {
+          "name": "convo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "convo_analysis_tags": {
+          "name": "convo_analysis_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "llm-convo-monitor_convo_id_unique": {
+          "name": "llm-convo-monitor_convo_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "convo_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm-guided-contexts": {
+      "name": "llm-guided-contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_tokens": {
+          "name": "num_tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm-guided-docs": {
+      "name": "llm-guided-docs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "doc_name": {
+          "name": "doc_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_tokens": {
+          "name": "num_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm-guided-sections": {
+      "name": "llm-guided-sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "num_tokens": {
+          "name": "num_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_title": {
+          "name": "section_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_num": {
+          "name": "section_num",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LLMProvider": {
+      "name": "LLMProvider",
+      "schema": "",
+      "columns": {
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_system_message": {
+          "name": "latest_system_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_prompt_engineered_message": {
+          "name": "final_prompt_engineered_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_sec": {
+          "name": "response_time_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_image_url": {
+          "name": "content_image_url",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_description": {
+          "name": "image_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_is_positive": {
+          "name": "feedback_is_positive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_category": {
+          "name": "feedback_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_details": {
+          "name": "feedback_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_query_rewritten": {
+          "name": "was_query_rewritten",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_rewrite_text": {
+          "name": "query_rewrite_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_content": {
+          "name": "processed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm-monitor-tags": {
+          "name": "llm-monitor-tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.n8n_workflows": {
+      "name": "n8n_workflows",
+      "schema": "",
+      "columns": {
+        "latest_workflow_id": {
+          "name": "latest_workflow_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nal_publications": {
+      "name": "nal_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pmid": {
+          "name": "pmid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_title": {
+          "name": "article_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_title": {
+          "name": "journal_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_authorized_api_keys": {
+      "name": "pre_authorized_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "providerBodyNoModels": {
+          "name": "providerBodyNoModels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emails": {
+          "name": "emails",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerName": {
+          "name": "providerName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_stats": {
+      "name": "project_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_messages": {
+          "name": "total_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_conversations": {
+          "name": "total_conversations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "unique_users": {
+          "name": "unique_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "model_usage_counts": {
+          "name": "model_usage_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_map_id": {
+          "name": "doc_map_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "convo_map_id": {
+          "name": "convo_map_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "n8n_api_key": {
+          "name": "n8n_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_uploaded_doc_id": {
+          "name": "last_uploaded_doc_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_uploaded_convo_id": {
+          "name": "last_uploaded_convo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_schema": {
+          "name": "metadata_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_map_index": {
+          "name": "conversation_map_index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_map_index": {
+          "name": "document_map_index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pmid": {
+          "name": "pmid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pmcid": {
+          "name": "pmcid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_title": {
+          "name": "journal_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_title": {
+          "name": "article_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issn": {
+          "name": "issn",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_revised": {
+          "name": "last_revised",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live": {
+          "name": "live",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pubmed_ftp_link": {
+          "name": "pubmed_ftp_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xml_filename": {
+          "name": "xml_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pubmed_daily_update": {
+      "name": "pubmed_daily_update",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pmid": {
+          "name": "pmid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pmcid": {
+          "name": "pmcid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_title": {
+          "name": "journal_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_title": {
+          "name": "article_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issn": {
+          "name": "issn",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_revised": {
+          "name": "last_revised",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live": {
+          "name": "live",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pubmed_ftp_link": {
+          "name": "pubmed_ftp_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xml_filename": {
+          "name": "xml_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraping_metadata_run": {
+      "name": "scraping_metadata_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_urls": {
+          "name": "max_urls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "scrape_strategy": {
+          "name": "scrape_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'equal-and-below'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraping_metadata_run_course_url_params_key": {
+          "name": "scraping_metadata_run_course_url_params_key",
+          "columns": [
+            {
+              "expression": "course_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "max_urls",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scrape_strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uiuc-course-table": {
+      "name": "uiuc-course-table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_prompt_price": {
+          "name": "total_prompt_price",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_completions_price": {
+          "name": "total_completions_price",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_embeddings_price": {
+          "name": "total_embeddings_price",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_queries": {
+          "name": "total_queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_metrics": {
+      "name": "usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_docs": {
+          "name": "total_docs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_convos": {
+          "name": "total_convos",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "most_recent_convo": {
+          "name": "most_recent_convo",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_name": {
+          "name": "admin_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/frontend/src/db/migrations/meta/0007_snapshot.json
+++ b/apps/frontend/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,2276 @@
+{
+  "id": "a45d76ad-601a-4e28-b497-f7971a420c1c",
+  "prevId": "9a64c243-9662-4ce0-84c2-26a1b9937e42",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keycloak_id": {
+          "name": "keycloak_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cedar_chunks": {
+      "name": "cedar_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_id": {
+          "name": "embedding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cedar_document_metadata": {
+      "name": "cedar_document_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cedar_documents": {
+      "name": "cedar_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_source": {
+          "name": "document_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_groups": {
+          "name": "doc_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cedar_runs": {
+      "name": "cedar_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_names": {
+      "name": "course_names",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_groups": {
+      "name": "doc_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "doc_count": {
+          "name": "doc_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "doc_groups_name_course_unique": {
+          "name": "doc_groups_name_course_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_groups_sharing": {
+      "name": "doc_groups_sharing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doc_group_id": {
+          "name": "doc_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_email": {
+          "name": "shared_with_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_level": {
+          "name": "permission_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "s3_path": {
+          "name": "s3_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "readable_filename": {
+          "name": "readable_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents_doc_groups": {
+      "name": "documents_doc_groups",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_group_id": {
+          "name": "doc_group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_doc_groups_pkey": {
+          "name": "documents_doc_groups_pkey",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doc_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents_failed": {
+      "name": "documents_failed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "s3_path": {
+          "name": "s3_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readable_filename": {
+          "name": "readable_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_groups": {
+          "name": "doc_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents_in_progress": {
+      "name": "documents_in_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "s3_path": {
+          "name": "s3_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readable_filename": {
+          "name": "readable_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_groups": {
+          "name": "doc_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beam_task_id": {
+          "name": "beam_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email-newsletter": {
+      "name": "email-newsletter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed-from-newsletter": {
+          "name": "unsubscribed-from-newsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_uploads": {
+      "name": "file_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readable_filename": {
+          "name": "readable_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_path": {
+          "name": "s3_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_entity": {
+      "name": "user_entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_constraint": {
+          "name": "email_constraint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "federation_link": {
+          "name": "federation_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_timestamp": {
+          "name": "created_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_account_client_link": {
+          "name": "service_account_client_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_before": {
+          "name": "not_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm-convo-monitor": {
+      "name": "llm-convo-monitor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "convo": {
+          "name": "convo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "convo_id": {
+          "name": "convo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "convo_analysis_tags": {
+          "name": "convo_analysis_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "llm-convo-monitor_convo_id_unique": {
+          "name": "llm-convo-monitor_convo_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "convo_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm-guided-contexts": {
+      "name": "llm-guided-contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_tokens": {
+          "name": "num_tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm-guided-docs": {
+      "name": "llm-guided-docs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "doc_name": {
+          "name": "doc_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_tokens": {
+          "name": "num_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm-guided-sections": {
+      "name": "llm-guided-sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "num_tokens": {
+          "name": "num_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_title": {
+          "name": "section_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_num": {
+          "name": "section_num",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LLMProvider": {
+      "name": "LLMProvider",
+      "schema": "",
+      "columns": {
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_system_message": {
+          "name": "latest_system_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_prompt_engineered_message": {
+          "name": "final_prompt_engineered_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_sec": {
+          "name": "response_time_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_image_url": {
+          "name": "content_image_url",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_description": {
+          "name": "image_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_is_positive": {
+          "name": "feedback_is_positive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_category": {
+          "name": "feedback_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_details": {
+          "name": "feedback_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_query_rewritten": {
+          "name": "was_query_rewritten",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_rewrite_text": {
+          "name": "query_rewrite_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_content": {
+          "name": "processed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm-monitor-tags": {
+          "name": "llm-monitor-tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.n8n_workflows": {
+      "name": "n8n_workflows",
+      "schema": "",
+      "columns": {
+        "latest_workflow_id": {
+          "name": "latest_workflow_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nal_publications": {
+      "name": "nal_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pmid": {
+          "name": "pmid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_title": {
+          "name": "article_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_title": {
+          "name": "journal_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_authorized_api_keys": {
+      "name": "pre_authorized_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "providerBodyNoModels": {
+          "name": "providerBodyNoModels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emails": {
+          "name": "emails",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerName": {
+          "name": "providerName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_stats": {
+      "name": "project_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_messages": {
+          "name": "total_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_conversations": {
+          "name": "total_conversations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "unique_users": {
+          "name": "unique_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "model_usage_counts": {
+          "name": "model_usage_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_map_id": {
+          "name": "doc_map_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "convo_map_id": {
+          "name": "convo_map_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "n8n_api_key": {
+          "name": "n8n_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_uploaded_doc_id": {
+          "name": "last_uploaded_doc_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_uploaded_convo_id": {
+          "name": "last_uploaded_convo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_schema": {
+          "name": "metadata_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_map_index": {
+          "name": "conversation_map_index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_map_index": {
+          "name": "document_map_index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pmid": {
+          "name": "pmid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pmcid": {
+          "name": "pmcid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_title": {
+          "name": "journal_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_title": {
+          "name": "article_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issn": {
+          "name": "issn",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_revised": {
+          "name": "last_revised",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live": {
+          "name": "live",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pubmed_ftp_link": {
+          "name": "pubmed_ftp_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xml_filename": {
+          "name": "xml_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pubmed_daily_update": {
+      "name": "pubmed_daily_update",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pmid": {
+          "name": "pmid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pmcid": {
+          "name": "pmcid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_title": {
+          "name": "journal_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_title": {
+          "name": "article_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issn": {
+          "name": "issn",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_revised": {
+          "name": "last_revised",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live": {
+          "name": "live",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pubmed_ftp_link": {
+          "name": "pubmed_ftp_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xml_filename": {
+          "name": "xml_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraping_metadata_documents": {
+      "name": "scraping_metadata_documents",
+      "schema": "",
+      "columns": {
+        "scrape_metadata_run_id": {
+          "name": "scrape_metadata_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraping_metadata_documents_document_id_idx": {
+          "name": "scraping_metadata_documents_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scraping_metadata_documents_scrape_metadata_run_id_scraping_metadata_run_id_fk": {
+          "name": "scraping_metadata_documents_scrape_metadata_run_id_scraping_metadata_run_id_fk",
+          "tableFrom": "scraping_metadata_documents",
+          "tableTo": "scraping_metadata_run",
+          "columnsFrom": [
+            "scrape_metadata_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scraping_metadata_documents_document_id_documents_id_fk": {
+          "name": "scraping_metadata_documents_document_id_documents_id_fk",
+          "tableFrom": "scraping_metadata_documents",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scraping_metadata_documents_scrape_metadata_run_id_document_id_pk": {
+          "name": "scraping_metadata_documents_scrape_metadata_run_id_document_id_pk",
+          "columns": [
+            "scrape_metadata_run_id",
+            "document_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraping_metadata_run": {
+      "name": "scraping_metadata_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_urls": {
+          "name": "max_urls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "scrape_strategy": {
+          "name": "scrape_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'equal-and-below'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraping_metadata_run_course_url_params_key": {
+          "name": "scraping_metadata_run_course_url_params_key",
+          "columns": [
+            {
+              "expression": "course_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "max_urls",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scrape_strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uiuc-course-table": {
+      "name": "uiuc-course-table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_prompt_price": {
+          "name": "total_prompt_price",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_completions_price": {
+          "name": "total_completions_price",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_embeddings_price": {
+          "name": "total_embeddings_price",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_queries": {
+          "name": "total_queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_metrics": {
+      "name": "usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "course_name": {
+          "name": "course_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_docs": {
+          "name": "total_docs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_convos": {
+          "name": "total_convos",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "most_recent_convo": {
+          "name": "most_recent_convo",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_name": {
+          "name": "admin_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/frontend/src/db/migrations/meta/_journal.json
+++ b/apps/frontend/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1769713616944,
       "tag": "0005_calm_valeria_richards",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1782085293878,
+      "tag": "0006_kind_lady_deathstrike",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/frontend/src/db/migrations/meta/_journal.json
+++ b/apps/frontend/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782085293878,
       "tag": "0006_kind_lady_deathstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1782854543324,
+      "tag": "0007_lush_paladin",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/frontend/src/db/schema.ts
+++ b/apps/frontend/src/db/schema.ts
@@ -221,6 +221,34 @@ export const courseNames = pgTable('course_names', {
   course_name: text('course_name'),
 })
 
+// Stored web-scrape parameters per project, so users can reuse them on future
+// scrapes. One row per distinct (course_name, url, max_urls, scrape_strategy);
+// re-running an identical scrape bumps last_run_at (see /api/scrapeWeb upsert).
+export const scrapeMetadataRun = pgTable(
+  'scraping_metadata_run',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    course_name: text('course_name').notNull(),
+    url: text('url').notNull(),
+    max_urls: integer('max_urls').default(50),
+    scrape_strategy: text('scrape_strategy').default('equal-and-below'),
+    created_at: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    last_run_at: timestamp('last_run_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    uniqueRun: uniqueIndex('scraping_metadata_run_course_url_params_key').on(
+      table.course_name,
+      table.url,
+      table.max_urls,
+      table.scrape_strategy,
+    ),
+  }),
+)
+
 // DocGroups table
 export const docGroups = pgTable(
   'doc_groups',

--- a/apps/frontend/src/db/schema.ts
+++ b/apps/frontend/src/db/schema.ts
@@ -6,9 +6,11 @@ import {
   boolean,
   date,
   doublePrecision,
+  index,
   integer,
   jsonb,
   pgTable,
+  primaryKey,
   serial,
   text,
   timestamp,
@@ -245,6 +247,33 @@ export const scrapeMetadataRun = pgTable(
       table.url,
       table.max_urls,
       table.scrape_strategy,
+    ),
+  }),
+)
+
+// Junction: which documents a saved scrape produced. Lets a re-crawl tell, per
+// URL, whether a doc already belongs to the scrape (existing) vs is new vs is
+// now missing — driving delete-missing / update-existing / add-new. Both FKs
+// cascade, so deleting a scrape run or a document removes only the link row.
+export const scrapeMetadataDocuments = pgTable(
+  'scraping_metadata_documents',
+  {
+    scrape_metadata_run_id: uuid('scrape_metadata_run_id')
+      .notNull()
+      .references(() => scrapeMetadataRun.id, { onDelete: 'cascade' }),
+    document_id: bigint('document_id', { mode: 'number' })
+      .notNull()
+      .references(() => documents.id, { onDelete: 'cascade' }),
+    created_at: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({
+      columns: [table.scrape_metadata_run_id, table.document_id],
+    }),
+    documentIdx: index('scraping_metadata_documents_document_id_idx').on(
+      table.document_id,
     ),
   }),
 )

--- a/apps/frontend/src/hooks/queries/useDeleteScrapeRun.ts
+++ b/apps/frontend/src/hooks/queries/useDeleteScrapeRun.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+async function deleteScrapeRun(
+  courseName: string,
+  id: string,
+  deleteFiles: boolean,
+): Promise<void> {
+  const params = new URLSearchParams({ course_name: courseName, id })
+  if (deleteFiles) params.append('delete_files', 'true')
+
+  const response = await fetch(`/api/scrapeRuns?${params.toString()}`, {
+    method: 'DELETE',
+  })
+
+  if (!response.ok) {
+    throw new Error(`Error deleting scrape run: ${response.status}`)
+  }
+}
+
+// Deletes a saved scrape (scraping_metadata_run row) and refreshes the
+// project's suggestion list. `mutate({ id, deleteFiles })`: when deleteFiles is
+// true the scrape's documents (S3 + vectors + rows) are deleted too, so the
+// documents and document-group caches are invalidated as well.
+export function useDeleteScrapeRun({ courseName }: { courseName: string }) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, deleteFiles }: { id: string; deleteFiles: boolean }) =>
+      deleteScrapeRun(courseName, id, deleteFiles),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scrapeRuns', courseName] })
+      queryClient.invalidateQueries({ queryKey: ['documents', courseName] })
+      queryClient.invalidateQueries({
+        queryKey: ['documentGroups', courseName],
+      })
+    },
+  })
+}

--- a/apps/frontend/src/hooks/queries/useFetchScrapeRuns.ts
+++ b/apps/frontend/src/hooks/queries/useFetchScrapeRuns.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query'
+import { type ScrapeRun } from '~/pages/api/scrapeRuns'
+
+interface UseFetchScrapeRunsOptions {
+  courseName: string
+  enabled?: boolean
+}
+
+async function fetchScrapeRuns(courseName: string): Promise<ScrapeRun[]> {
+  const response = await fetch(
+    `/api/scrapeRuns?course_name=${encodeURIComponent(courseName)}`,
+  )
+
+  if (!response.ok) {
+    throw new Error(`Error fetching scrape runs: ${response.status}`)
+  }
+
+  const data: { runs: ScrapeRun[] } = await response.json()
+  return data.runs ?? []
+}
+
+// Past web-scrape parameter sets for a project, most-recently-used first.
+export function useFetchScrapeRuns({
+  courseName,
+  enabled = true,
+}: UseFetchScrapeRunsOptions) {
+  return useQuery({
+    queryKey: ['scrapeRuns', courseName],
+    queryFn: () => fetchScrapeRuns(courseName),
+    retry: 1,
+    enabled: enabled && Boolean(courseName),
+  })
+}

--- a/apps/frontend/src/pages/api/scrapeRuns.ts
+++ b/apps/frontend/src/pages/api/scrapeRuns.ts
@@ -7,7 +7,7 @@ import {
   scrapeMetadataDocuments,
   documents,
 } from '~/db/dbClient'
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, sql } from 'drizzle-orm'
 import { deleteScrapeRunDocuments } from '~/utils/scrapeRunFiles'
 
 export interface ScrapeRun {
@@ -18,6 +18,10 @@ export interface ScrapeRun {
   scrape_strategy: string | null
   created_at: string
   last_run_at: string
+  // Live count of documents currently linked to this scrape (junction rows).
+  // The junction FK cascades on document delete, so this always reflects the
+  // real number of files the scrape still owns.
+  document_count: number
 }
 
 // GET    /api/scrapeRuns?course_name=<project>            -> past scrape param sets, most-recent first
@@ -36,10 +40,30 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
 
   if (req.method === 'GET') {
     try {
+      // Left join the junction and count per run so each row carries a live
+      // document_count. Group by the run PK (functional dependency covers the
+      // other selected columns).
       const runs = await db
-        .select()
+        .select({
+          id: scrapeMetadataRun.id,
+          course_name: scrapeMetadataRun.course_name,
+          url: scrapeMetadataRun.url,
+          max_urls: scrapeMetadataRun.max_urls,
+          scrape_strategy: scrapeMetadataRun.scrape_strategy,
+          created_at: scrapeMetadataRun.created_at,
+          last_run_at: scrapeMetadataRun.last_run_at,
+          document_count: sql<number>`count(${scrapeMetadataDocuments.document_id})::int`,
+        })
         .from(scrapeMetadataRun)
+        .leftJoin(
+          scrapeMetadataDocuments,
+          eq(
+            scrapeMetadataDocuments.scrape_metadata_run_id,
+            scrapeMetadataRun.id,
+          ),
+        )
         .where(eq(scrapeMetadataRun.course_name, courseName))
+        .groupBy(scrapeMetadataRun.id)
         .orderBy(desc(scrapeMetadataRun.last_run_at))
 
       return res.status(200).json({ runs })

--- a/apps/frontend/src/pages/api/scrapeRuns.ts
+++ b/apps/frontend/src/pages/api/scrapeRuns.ts
@@ -1,8 +1,14 @@
 import { type NextApiResponse } from 'next'
 import { type AuthenticatedRequest } from '~/utils/authMiddleware'
 import { withCourseOwnerOrAdminAccess } from '~/pages/api/authorization'
-import { db, scrapeMetadataRun } from '~/db/dbClient'
-import { desc, eq } from 'drizzle-orm'
+import {
+  db,
+  scrapeMetadataRun,
+  scrapeMetadataDocuments,
+  documents,
+} from '~/db/dbClient'
+import { and, desc, eq } from 'drizzle-orm'
+import { deleteScrapeRunDocuments } from '~/utils/scrapeRunFiles'
 
 export interface ScrapeRun {
   id: string
@@ -14,10 +20,12 @@ export interface ScrapeRun {
   last_run_at: string
 }
 
-// GET /api/scrapeRuns?course_name=<project> -> past scrape param sets, most-recent first
+// GET    /api/scrapeRuns?course_name=<project>            -> past scrape param sets, most-recent first
+// DELETE /api/scrapeRuns?course_name=<project>&id=<uuid>  -> remove one saved scrape
 //
 // One row per distinct (url, max_urls, scrape_strategy) thanks to the upsert in
-// /api/scrapeWeb.
+// /api/scrapeWeb. Deleting only removes the reusable parameter row; it does not
+// touch any scraped documents.
 async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
   const courseName =
     (req.query.course_name as string) || (req.query.courseName as string)
@@ -39,6 +47,69 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
       console.error('Error fetching scrape runs:', error)
       return res.status(500).json({
         error: 'Failed to fetch scrape runs',
+        details: (error as Error).message,
+      })
+    }
+  }
+
+  if (req.method === 'DELETE') {
+    const id = req.query.id as string
+    if (!id) {
+      return res.status(400).json({ error: 'Missing required id' })
+    }
+
+    const deleteFiles = req.query.delete_files === 'true'
+
+    try {
+      // When asked, delete the documents this scrape produced BEFORE removing
+      // the run row. Look them up via the junction so we only touch this run's
+      // pages, then route each through the backend /delete (S3 + vectors + row).
+      if (deleteFiles) {
+        const linkedDocs = await db
+          .select({
+            s3_path: documents.s3_path,
+            url: documents.url,
+            course_name: documents.course_name,
+          })
+          .from(scrapeMetadataDocuments)
+          .innerJoin(
+            documents,
+            eq(scrapeMetadataDocuments.document_id, documents.id),
+          )
+          .where(eq(scrapeMetadataDocuments.scrape_metadata_run_id, id))
+
+        const { deletedCount, failedCount } = await deleteScrapeRunDocuments(
+          courseName,
+          linkedDocs,
+        )
+
+        // Any failure: keep the run row (and its junction links) so the user can
+        // retry, and report what happened.
+        if (failedCount > 0) {
+          return res.status(500).json({
+            error: 'Some files could not be deleted; saved scrape kept.',
+            deletedCount,
+            failedCount,
+          })
+        }
+      }
+
+      // Scope to BOTH id and course_name so a row can only ever be deleted
+      // within the project the caller has access to. Junction rows cascade.
+      await db
+        .delete(scrapeMetadataRun)
+        .where(
+          and(
+            eq(scrapeMetadataRun.id, id),
+            eq(scrapeMetadataRun.course_name, courseName),
+          ),
+        )
+
+      return res.status(200).json({ success: true })
+    } catch (error) {
+      console.error('Error deleting scrape run:', error)
+      return res.status(500).json({
+        error: 'Failed to delete scrape run',
         details: (error as Error).message,
       })
     }

--- a/apps/frontend/src/pages/api/scrapeRuns.ts
+++ b/apps/frontend/src/pages/api/scrapeRuns.ts
@@ -1,0 +1,50 @@
+import { type NextApiResponse } from 'next'
+import { type AuthenticatedRequest } from '~/utils/authMiddleware'
+import { withCourseOwnerOrAdminAccess } from '~/pages/api/authorization'
+import { db, scrapeMetadataRun } from '~/db/dbClient'
+import { desc, eq } from 'drizzle-orm'
+
+export interface ScrapeRun {
+  id: string
+  course_name: string
+  url: string
+  max_urls: number | null
+  scrape_strategy: string | null
+  created_at: string
+  last_run_at: string
+}
+
+// GET /api/scrapeRuns?course_name=<project> -> past scrape param sets, most-recent first
+//
+// One row per distinct (url, max_urls, scrape_strategy) thanks to the upsert in
+// /api/scrapeWeb.
+async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
+  const courseName =
+    (req.query.course_name as string) || (req.query.courseName as string)
+
+  if (!courseName) {
+    return res.status(400).json({ error: 'Missing required course_name' })
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const runs = await db
+        .select()
+        .from(scrapeMetadataRun)
+        .where(eq(scrapeMetadataRun.course_name, courseName))
+        .orderBy(desc(scrapeMetadataRun.last_run_at))
+
+      return res.status(200).json({ runs })
+    } catch (error) {
+      console.error('Error fetching scrape runs:', error)
+      return res.status(500).json({
+        error: 'Failed to fetch scrape runs',
+        details: (error as Error).message,
+      })
+    }
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}
+
+export default withCourseOwnerOrAdminAccess()(handler)

--- a/apps/frontend/src/pages/api/scrapeWeb.ts
+++ b/apps/frontend/src/pages/api/scrapeWeb.ts
@@ -9,6 +9,10 @@ interface ScrapeRequestBody {
   courseName: string | null
   maxUrls: number
   scrapeStrategy: string
+  // Only present on an "unchanged reuse" re-ingest. Absent for new/changed scrapes.
+  deleteMissing?: boolean
+  updateExisting?: boolean
+  addNew?: boolean
 }
 
 export default withCourseOwnerOrAdminAccess()(handler)
@@ -47,7 +51,7 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const { url, courseName, maxUrls, scrapeStrategy } =
+  const { url, courseName, maxUrls, scrapeStrategy, deleteMissing, updateExisting, addNew } =
     req.body as ScrapeRequestBody
 
   if (!url || !courseName) {
@@ -59,10 +63,12 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
 
     // Record the scrape parameters so users can reuse them on future scrapes.
     // One row per distinct (course_name, url, max_urls, scrape_strategy);
-    // re-running an identical scrape just bumps last_run_at. A DB failure here
-    // must not block the actual scrape, so it's best-effort.
+    // re-running an identical scrape just bumps last_run_at. We need the row id
+    // to thread to Crawlee (so ingested docs get linked to this scrape). A DB
+    // failure here must not block the actual scrape, so it's best-effort.
+    let scrapeMetadataRunId: string | undefined
     try {
-      await db
+      const rows = await db
         .insert(scrapeMetadataRun)
         .values({
           course_name: courseName,
@@ -79,6 +85,8 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
           ],
           set: { last_run_at: new Date() },
         })
+        .returning({ id: scrapeMetadataRun.id })
+      scrapeMetadataRunId = rows[0]?.id
     } catch (recordError) {
       console.error('Failed to record scrape run metadata:', recordError)
     }
@@ -90,6 +98,13 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
       scrapeStrategy: scrapeStrategy,
       match: formatUrlAndMatchRegex(fullUrl).matchRegex,
       maxTokens: 2000000,
+      // Threaded to Crawlee -> each page's /ingest body -> the worker, which
+      // links the resulting document to this scrape run. The three flags are
+      // only meaningful on an unchanged-reuse re-ingest (otherwise undefined).
+      scrapeMetadataRunId,
+      deleteMissing,
+      updateExisting,
+      addNew,
     }
 
     const crawleeApiUrl = process.env.CRAWLEE_API_URL

--- a/apps/frontend/src/pages/api/scrapeWeb.ts
+++ b/apps/frontend/src/pages/api/scrapeWeb.ts
@@ -2,6 +2,7 @@ import { type NextApiResponse } from 'next'
 import { type AuthenticatedRequest } from '~/utils/authMiddleware'
 import axios from 'axios'
 import { withCourseOwnerOrAdminAccess } from '~/pages/api/authorization'
+import { db, scrapeMetadataRun } from '~/db/dbClient'
 
 interface ScrapeRequestBody {
   url: string | null
@@ -55,6 +56,33 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
 
   try {
     const fullUrl = formatUrl(url)
+
+    // Record the scrape parameters so users can reuse them on future scrapes.
+    // One row per distinct (course_name, url, max_urls, scrape_strategy);
+    // re-running an identical scrape just bumps last_run_at. A DB failure here
+    // must not block the actual scrape, so it's best-effort.
+    try {
+      await db
+        .insert(scrapeMetadataRun)
+        .values({
+          course_name: courseName,
+          url: fullUrl,
+          max_urls: maxUrls,
+          scrape_strategy: scrapeStrategy,
+        })
+        .onConflictDoUpdate({
+          target: [
+            scrapeMetadataRun.course_name,
+            scrapeMetadataRun.url,
+            scrapeMetadataRun.max_urls,
+            scrapeMetadataRun.scrape_strategy,
+          ],
+          set: { last_run_at: new Date() },
+        })
+    } catch (recordError) {
+      console.error('Failed to record scrape run metadata:', recordError)
+    }
+
     const postParams = {
       url: fullUrl,
       courseName: courseName,

--- a/apps/frontend/src/pages/api/scrapeWeb.ts
+++ b/apps/frontend/src/pages/api/scrapeWeb.ts
@@ -21,7 +21,8 @@ const formatUrl = (url: string) => {
   if (!/^https?:\/\//i.test(url)) {
     url = 'http://' + url
   }
-  return url
+  // Canonicalize trailing slashes.
+  return url.replace(/\/+$/, '')
 }
 
 const formatUrlAndMatchRegex = (url: string) => {

--- a/apps/frontend/src/utils/__tests__/scrapeRunFiles.test.ts
+++ b/apps/frontend/src/utils/__tests__/scrapeRunFiles.test.ts
@@ -1,0 +1,80 @@
+/* @vitest-environment node */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { deleteScrapeRunDocuments } from '../scrapeRunFiles'
+
+beforeEach(() => {
+  // getBackendUrl() throws without RAILWAY_URL; stub it so the test is
+  // self-contained and deterministic (vitest does not load .env.local).
+  vi.stubEnv('RAILWAY_URL', 'http://backend.test')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+describe('deleteScrapeRunDocuments', () => {
+  it('returns zero counts and makes no calls when there are no docs', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await deleteScrapeRunDocuments('CS101', [])
+
+    expect(result).toEqual({ deletedCount: 0, failedCount: 0 })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('calls the backend /delete once per doc with course_name, s3_path and url', async () => {
+    const fetchMock = vi.fn(
+      async (_url: string | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await deleteScrapeRunDocuments('CS101', [
+      { s3_path: 'courses/CS101/a.pdf', url: null, course_name: 'CS101' },
+      { s3_path: null, url: 'https://example.com/p1', course_name: 'CS101' },
+    ])
+
+    expect(result).toEqual({ deletedCount: 2, failedCount: 0 })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const firstUrl = String(fetchMock.mock.calls[0]![0])
+    expect(firstUrl).toContain('/delete?')
+    expect(firstUrl).toContain('course_name=CS101')
+    expect(firstUrl).toContain('s3_path=courses%2FCS101%2Fa.pdf')
+    const secondUrl = String(fetchMock.mock.calls[1]![0])
+    expect(secondUrl).toContain('url=https%3A%2F%2Fexample.com%2Fp1')
+    expect(fetchMock.mock.calls[0]![1]).toMatchObject({ method: 'DELETE' })
+  })
+
+  it('counts a non-ok response as a failure', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 200 }))
+      .mockResolvedValueOnce(new Response('', { status: 500 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await deleteScrapeRunDocuments('CS101', [
+      { s3_path: 's1', url: null, course_name: 'CS101' },
+      { s3_path: 's2', url: null, course_name: 'CS101' },
+    ])
+
+    expect(result).toEqual({ deletedCount: 1, failedCount: 1 })
+  })
+
+  it('counts a rejected fetch as a failure', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 200 }))
+      .mockRejectedValueOnce(new Error('network'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await deleteScrapeRunDocuments('CS101', [
+      { s3_path: 's1', url: null, course_name: 'CS101' },
+      { s3_path: 's2', url: null, course_name: 'CS101' },
+    ])
+
+    expect(result).toEqual({ deletedCount: 1, failedCount: 1 })
+  })
+})

--- a/apps/frontend/src/utils/scrapeRunFiles.ts
+++ b/apps/frontend/src/utils/scrapeRunFiles.ts
@@ -1,0 +1,44 @@
+import { getBackendUrl } from '~/utils/apiUtils'
+
+// A scraped document as far as deletion cares: enough to address it in the
+// backend delete (which handles S3 + vector DB + the documents row).
+export interface ScrapeRunDoc {
+  s3_path: string | null
+  url: string | null
+  course_name: string | null
+}
+
+export interface DeleteScrapeRunDocsResult {
+  deletedCount: number
+  failedCount: number
+}
+
+// Delete every document a scrape run produced by calling the backend /delete
+// endpoint once per doc — the same call /api/UIUC-api/deleteDocument makes.
+// Best-effort per file via allSettled; the caller decides what to do with a
+// non-zero failedCount. `courseName` scopes the call to the caller's project;
+// each doc's own course_name is preferred when present.
+export async function deleteScrapeRunDocuments(
+  courseName: string,
+  docs: ScrapeRunDoc[],
+): Promise<DeleteScrapeRunDocsResult> {
+  const results = await Promise.allSettled(
+    docs.map(async (doc) => {
+      const params = new URLSearchParams()
+      params.append('course_name', doc.course_name || courseName)
+      if (doc.s3_path) params.append('s3_path', doc.s3_path)
+      if (doc.url) params.append('url', doc.url)
+
+      const response = await fetch(
+        `${getBackendUrl()}/delete?${params.toString()}`,
+        { method: 'DELETE' },
+      )
+      if (!response.ok) {
+        throw new Error(`Delete failed with status ${response.status}`)
+      }
+    }),
+  )
+
+  const failedCount = results.filter((r) => r.status === 'rejected').length
+  return { deletedCount: results.length - failedCount, failedCount }
+}


### PR DESCRIPTION
## Summary

Adds a "store & reuse web scrape" workflow to the ingest form. Every web scrape's parameters are saved per project and offered back as autocomplete suggestions, so re-scraping a site is a two-click operation instead of re-typing the URL, crawl depth, and strategy. Each saved scrape also tracks exactly which documents it produced, which unlocks re-ingest controls (add new / update changed / delete missing pages), an optional "delete the files too" path, and a live per-scrape document count.

Spans all three apps (`frontend`, `backend`, `crawlee`).

## What's included (commit by commit)

1. **Save scrape parameters and suggest them in the URL field**
   - New `scraping_metadata_run` table: one row per distinct `(course_name, url, max_urls, scrape_strategy)`; an identical re-run just bumps `last_run_at`.
   - `POST /api/scrapeWeb` upserts the row; `GET /api/scrapeRuns` lists a project's saved scrapes (most-recent first).
   - The URL `Input` becomes a Mantine `Autocomplete`: selecting a suggestion auto-applies its saved max-URLs and strategy.

2. **Track scraped documents per run + re-ingest options**
   - New `scraping_metadata_documents` junction (`run_id`, `document_id`; both FKs `ON DELETE CASCADE`). The worker links each ingested page to its run.
   - When the form exactly matches a saved scrape, three toggles appear — **Add newly found pages**, **Update pages that changed**, **Delete pages no longer found** — and the button reads "Re-ingest the Website".
   - Backend classify gate skips pages per the flags before any embed/insert work. A new `/finalizeScrapeRun` endpoint (called by Crawlee at end of crawl) deletes docs whose URLs were not seen this crawl, scoped to the run so concurrent scrapes never delete each other's docs.

3. **Delete a saved scrape, optionally with its files**
   - Saved scrapes can be removed from the autocomplete dropdown via a confirm overlay.
   - A toggle deletes the documents the scrape produced (S3 + vectors + rows) via the existing backend `/delete` path. If any file fails, the saved scrape row is **kept** so the deletion can be retried (no orphaned files).

4. **Live document counts per saved scrape**
   - `GET /api/scrapeRuns` returns `document_count` (a `COUNT` over the junction), shown in each suggestion's summary and in the delete dialog.
   - Deleting files from the project table invalidates the scrape-run query so the count updates in real time.

5. **Preserve doc-group membership across re-scrape updates**
   - When a re-scrape updates a page, the old `documents` row is deleted and a new one inserted, which would drop the page's doc-group membership. The worker now captures the page's groups before the delete and re-attaches them after the re-insert. New pages stay ungrouped; deleted pages fall out naturally.

## Database changes

- Migrations **0006** (`scraping_metadata_run`) and **0007** (`scraping_metadata_documents`) — reviewers/deployers must apply both.
- No changes to existing tables.

## API surface

| Endpoint | Change |
|---|---|
| `POST /api/scrapeWeb` | Upserts the run row; threads run id + re-ingest flags to Crawlee |
| `GET /api/scrapeRuns` | Lists saved scrapes with live `document_count` |
| `DELETE /api/scrapeRuns` | Removes a saved scrape; `?delete_files=true` also deletes its documents |
| `POST /finalizeScrapeRun` (backend) | Delete-missing finalize for a completed crawl |

## Testing

- Frontend: `vitest` — new coverage for `deleteScrapeRunDocuments` and the delete-files toggle behavior; existing `WebsiteIngestForm` tests still pass.
- `tsc --noEmit` clean on all touched files.
- Backend: `py_compile` clean.
- Manual end-to-end on a local stack: fresh scrape, re-scrape with each toggle combination, delete-with-files, and group preservation across an update.

## Notes for reviewers

- The `scraping_metadata_documents` junction declares its own cascade FKs, so this PR is self-contained. (A separate PR fixes the pre-existing, unrelated `documents_doc_groups` table, which lacked a document FK.)
- Crawlee's `getPageHtml` now hides `nav/header/footer` (via `display:none`) instead of removing them, so their links remain crawlable while their text stays excluded.