### PR TITLE
fix(db): cascade documents_doc_groups when a document is deleted

### DIFF
--- a/apps/backend/ai_ta_backend/rabbitmq/models.py
+++ b/apps/backend/ai_ta_backend/rabbitmq/models.py
@@ -59,7 +59,7 @@ class Document(Base):
 
 class DocumentDocGroup(Base):
     __tablename__ = 'documents_doc_groups'
-    document_id = Column(BigInteger, primary_key=True)
+    document_id = Column(BigInteger, ForeignKey('documents.id', ondelete='CASCADE'), primary_key=True)
     doc_group_id = Column(BigInteger, ForeignKey('doc_groups.id', ondelete='CASCADE'), primary_key=True)
     created_at = Column(DateTime, default=func.now())
 

--- a/apps/frontend/src/db/schema.ts
+++ b/apps/frontend/src/db/schema.ts
@@ -247,7 +247,11 @@ export const docGroups = pgTable(
 export const documentsDocGroups = pgTable(
   'documents_doc_groups',
   {
-    document_id: bigint('document_id', { mode: 'number' }).notNull(),
+    // FK cascade: deleting a document (or group) removes the link row, which
+    // fires update_doc_count() to keep doc_groups.doc_count accurate.
+    document_id: bigint('document_id', { mode: 'number' })
+      .notNull()
+      .references(() => documents.id, { onDelete: 'cascade' }),
     doc_group_id: bigint('doc_group_id', { mode: 'number' }).notNull(),
     created_at: timestamp('created_at').defaultNow(),
   },

--- a/infra/db/migrations/docgroups_document_fk.sql
+++ b/infra/db/migrations/docgroups_document_fk.sql
@@ -1,0 +1,34 @@
+-- Fix: deleting a document must also remove its doc-group links so group
+-- doc_count stays accurate.
+--
+-- The Supabase dump / drizzle schema never defined a foreign key from
+-- documents_doc_groups.document_id to documents.id, so on plain Postgres a
+-- document delete left orphaned link rows behind. The doc_count column is
+-- maintained by the update_doc_count() AFTER INSERT/DELETE trigger on
+-- documents_doc_groups, so those orphaned rows also inflated every group's
+-- count (they were never DELETEd, so the trigger never decremented).
+--
+-- This migration is idempotent: safe to run on every init.
+
+-- 1) Remove any pre-existing orphaned links (documents that no longer exist).
+--    The AFTER DELETE trigger decrements each affected group's doc_count.
+DELETE FROM public.documents_doc_groups ddg
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.documents d WHERE d.id = ddg.document_id
+);
+
+-- 2) Add the cascading FK so future document deletes clean up their links
+--    (and fire the trigger to keep doc_count correct). Guarded so re-runs
+--    don't error (ADD CONSTRAINT has no IF NOT EXISTS).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'documents_doc_groups_document_id_fkey'
+      AND conrelid = 'public.documents_doc_groups'::regclass
+  ) THEN
+    ALTER TABLE public.documents_doc_groups
+      ADD CONSTRAINT documents_doc_groups_document_id_fkey
+      FOREIGN KEY (document_id) REFERENCES public.documents(id) ON DELETE CASCADE;
+  END IF;
+END$$;


### PR DESCRIPTION
## Summary

Deleting a document left rows in `documents_doc_groups` because `document_id` had no FK. Group `doc_count` (maintained by a trigger on that junction table) never decremented, so counts drifted up (e.g. 19 shown vs 5 real docs).

## Fix

- Add `ON DELETE CASCADE` on `documents_doc_groups.document_id` in Drizzle (`schema.ts`) and SQLAlchemy (`models.py`).
- Idempotent migration: delete existing orphan links, then add the FK (guarded for re-runs).

Document deletes (single, bulk, scrape) now remove group links and update counts correctly.

## Testing

Verified on live DB: inflated counts corrected after cleanup; delete cascades links and decrements `doc_count`. Migration is safe to re-run.

## Notes

Independent of scrape-tracking PR. FK is hand-written SQL rather than drizzle-kit generated to avoid renumbering migrations.