### PR TITLE
refactor(frontend): retire Mantine from hub pages (slice 4)

### DIFF
--- a/apps/frontend/src/components/UIUC-Components/Dashboard.tsx
+++ b/apps/frontend/src/components/UIUC-Components/Dashboard.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import { useEffect, useState } from 'react'
 
+import { Card } from '@/components/shadcn/ui/card'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import router from 'next/router'
 import { createProject } from '~/utils/apiUtils'
@@ -126,15 +127,15 @@ const Dashboard = ({
             </p>
           </div>
 
-          <div
-            className="mt-8 min-h-[10rem] overflow-hidden rounded-[2rem] border"
+          <Card
+            className="mt-8 min-h-[10rem] gap-0 rounded-[2rem] border py-0 text-base shadow-none ring-0"
             style={{
               backgroundColor: 'var(--background)',
               borderColor: 'var(--dashboard-border)',
             }}
           >
             <ProjectTable />
-          </div>
+          </Card>
         </div>
       </main>
 

--- a/apps/frontend/src/components/UIUC-Components/Dashboard.tsx
+++ b/apps/frontend/src/components/UIUC-Components/Dashboard.tsx
@@ -1,8 +1,6 @@
 import Head from 'next/head'
 import { useEffect, useState } from 'react'
 
-import { Card, Title } from '@mantine/core'
-import { useMediaQuery } from '@mantine/hooks'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import router from 'next/router'
 import { createProject } from '~/utils/apiUtils'
@@ -22,7 +20,6 @@ const Dashboard = ({
   is_new_course?: boolean
   project_description?: string
 }) => {
-  const isSmallScreen = useMediaQuery('(max-width: 960px)')
   const [projectName, setProjectName] = useState(project_name || '')
   const [projectDescription, setProjectDescription] = useState(
     project_description || '',
@@ -114,13 +111,12 @@ const Dashboard = ({
       >
         <div className="mx-auto mt-[2%] min-h-[70vh] w-[96%] md:w-[90%] 2xl:w-[90%]">
           <div className="px-8">
-            <Title
-              order={1}
+            <h1
               className={`text-2xl font-bold sm:pt-2 ${montserrat_heading.variable} font-montserratHeading`}
               style={{ color: 'var(--foreground)' }}
             >
               My Chatbots
-            </Title>
+            </h1>
 
             <p
               className={`text-md mt-2 ${montserrat_paragraph.variable} font-montserratParagraph`}
@@ -130,18 +126,15 @@ const Dashboard = ({
             </p>
           </div>
 
-          <Card
-            withBorder
-            padding="none"
-            radius="xl"
-            className="mt-8 min-h-[10rem]"
+          <div
+            className="mt-8 min-h-[10rem] overflow-hidden rounded-[2rem] border"
             style={{
               backgroundColor: 'var(--background)',
               borderColor: 'var(--dashboard-border)',
             }}
           >
             <ProjectTable />
-          </Card>
+          </div>
         </div>
       </main>
 

--- a/apps/frontend/src/components/UIUC-Components/Explore.tsx
+++ b/apps/frontend/src/components/UIUC-Components/Explore.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import { useEffect, useState } from 'react'
 
+import { Card } from '@/components/shadcn/ui/card'
 import router from 'next/router'
 import { createProject } from '~/utils/apiUtils'
 import Navbar from './navbars/Navbar'
@@ -108,8 +109,8 @@ const Dashboard = ({
         }}
       >
         <h1 className="sr-only">Explore Chatbots</h1>
-        <div
-          className="mx-auto mt-[2%] w-[96%] overflow-hidden rounded-[2rem] border md:w-[90%] 2xl:w-[90%]"
+        <Card
+          className="mx-auto mt-[2%] w-[96%] gap-0 rounded-[2rem] border py-0 text-base shadow-none ring-0 md:w-[90%] 2xl:w-[90%]"
           style={{
             backgroundColor: 'var(--background)',
             borderColor: 'var(--dashboard-border)',
@@ -124,7 +125,7 @@ const Dashboard = ({
               LLMs, chatbots, and AI…oh my!
             </div>
           </div>
-        </div>
+        </Card>
       </main>
 
       <GlobalFooter />

--- a/apps/frontend/src/components/UIUC-Components/Explore.tsx
+++ b/apps/frontend/src/components/UIUC-Components/Explore.tsx
@@ -1,8 +1,6 @@
 import Head from 'next/head'
 import { useEffect, useState } from 'react'
 
-import { Card } from '@mantine/core'
-import { useMediaQuery } from '@mantine/hooks'
 import router from 'next/router'
 import { createProject } from '~/utils/apiUtils'
 import Navbar from './navbars/Navbar'
@@ -20,7 +18,6 @@ const Dashboard = ({
   is_new_course?: boolean
   project_description?: string
 }) => {
-  const isSmallScreen = useMediaQuery('(max-width: 960px)')
   const [projectName, setProjectName] = useState(project_name || '')
   const [projectDescription, setProjectDescription] = useState(
     project_description || '',
@@ -111,11 +108,8 @@ const Dashboard = ({
         }}
       >
         <h1 className="sr-only">Explore Chatbots</h1>
-        <Card
-          withBorder
-          padding="none"
-          radius="xl"
-          className="mx-auto mt-[2%] w-[96%] md:w-[90%] 2xl:w-[90%]"
+        <div
+          className="mx-auto mt-[2%] w-[96%] overflow-hidden rounded-[2rem] border md:w-[90%] 2xl:w-[90%]"
           style={{
             backgroundColor: 'var(--background)',
             borderColor: 'var(--dashboard-border)',
@@ -130,7 +124,7 @@ const Dashboard = ({
               LLMs, chatbots, and AI…oh my!
             </div>
           </div>
-        </Card>
+        </div>
       </main>
 
       <GlobalFooter />

--- a/apps/frontend/src/components/UIUC-Components/PermissionGate.tsx
+++ b/apps/frontend/src/components/UIUC-Components/PermissionGate.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Link from 'next/link'
 import Head from 'next/head'
 import { useAuth } from 'react-oidc-context'
+import { Button } from '@/components/shadcn/ui/button'
 import { montserrat_heading } from 'fonts'
 import { initiateSignIn } from '~/utils/authHelpers'
 
@@ -87,12 +88,12 @@ export const PermissionGate = ({
             </p>
             {errorType === 403 && (
               <Link href="/chatbots">
-                <button
-                  className="login-btn btn bg-[--button] text-white hover:bg-[--button-hover]"
+                <Button
+                  className="login-btn btn h-auto bg-[--button] text-white hover:bg-[--button-hover]"
                   style={{ fontSize: '24px' }}
                 >
                   My Chatbots →
-                </button>
+                </Button>
               </Link>
             )}
             {errorType === 404 && (
@@ -103,23 +104,23 @@ export const PermissionGate = ({
                     : '/new'
                 }
               >
-                <button
-                  className="login-btn btn bg-[--button] text-white hover:bg-[--button-hover]"
+                <Button
+                  className="login-btn btn h-auto bg-[--button] text-white hover:bg-[--button-hover]"
                   style={{ fontSize: '24px' }}
                 >
                   Create New →
-                </button>
+                </Button>
               </Link>
             )}
             {errorType !== 404 && errorType !== 403 && (
               <Link href="/sign-in">
-                <button
-                  className="login-btn btn bg-[--button] text-white hover:bg-[--button-hover]"
+                <Button
+                  className="login-btn btn h-auto bg-[--button] text-white hover:bg-[--button-hover]"
                   style={{ fontSize: '24px' }}
                   onClick={handleSignIn}
                 >
                   Sign in →
-                </button>
+                </Button>
               </Link>
             )}
           </div>

--- a/apps/frontend/src/components/UIUC-Components/PermissionGate.tsx
+++ b/apps/frontend/src/components/UIUC-Components/PermissionGate.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
 import Head from 'next/head'
-import { Button, Title, Flex, Text } from '@mantine/core'
 import { useAuth } from 'react-oidc-context'
 import { montserrat_heading } from 'fonts'
 import { initiateSignIn } from '~/utils/authHelpers'
@@ -74,31 +73,26 @@ export const PermissionGate = ({
           </Link>
         </div>
         <div className="items-left container flex flex-col justify-center gap-2 py-0">
-          <Flex direction="column" align="center" justify="center">
-            <Title
-              className={`${montserrat_heading.variable} font-montserratHeading text-[--foreground]`}
-              order={2}
-              p="xl"
+          <div className="flex flex-col items-center justify-center">
+            <h2
+              className={`${montserrat_heading.variable} p-8 font-montserratHeading text-[2.2rem] font-bold text-[--foreground]`}
             >
               {' '}
               {getTitle()}
-            </Title>
-            <Text
-              className={`${montserrat_heading.variable} font-montserratHeading text-[--foreground]`}
-              size="lg"
-              p="md"
-              ta="center"
+            </h2>
+            <p
+              className={`${montserrat_heading.variable} p-4 text-center font-montserratHeading text-lg text-[--foreground]`}
             >
               {getErrorMessage()}
-            </Text>
+            </p>
             {errorType === 403 && (
               <Link href="/chatbots">
-                <Button
+                <button
                   className="login-btn btn bg-[--button] text-white hover:bg-[--button-hover]"
                   style={{ fontSize: '24px' }}
                 >
                   My Chatbots →
-                </Button>
+                </button>
               </Link>
             )}
             {errorType === 404 && (
@@ -109,26 +103,26 @@ export const PermissionGate = ({
                     : '/new'
                 }
               >
-                <Button
+                <button
                   className="login-btn btn bg-[--button] text-white hover:bg-[--button-hover]"
                   style={{ fontSize: '24px' }}
                 >
                   Create New →
-                </Button>
+                </button>
               </Link>
             )}
             {errorType !== 404 && errorType !== 403 && (
               <Link href="/sign-in">
-                <Button
+                <button
                   className="login-btn btn bg-[--button] text-white hover:bg-[--button-hover]"
                   style={{ fontSize: '24px' }}
                   onClick={handleSignIn}
                 >
                   Sign in →
-                </Button>
+                </button>
               </Link>
             )}
-          </Flex>
+          </div>
         </div>
       </main>
     </>

--- a/apps/frontend/src/components/UIUC-Components/ProjectTable.tsx
+++ b/apps/frontend/src/components/UIUC-Components/ProjectTable.tsx
@@ -1,5 +1,4 @@
 import { useAuth } from 'react-oidc-context'
-import { Table, Text } from '@mantine/core'
 import { useMemo, useState } from 'react'
 import { type CourseMetadata } from '~/types/courseMetadata'
 import { isSuperAdmin } from '~/utils/superAdmins'
@@ -8,7 +7,6 @@ import styled from 'styled-components'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import Link from 'next/link'
 import React from 'react'
-import { useMediaQuery } from '@mantine/hooks'
 import {
   IconChevronUp,
   IconChevronDown,
@@ -23,9 +21,10 @@ const StyledRow = styled.tr`
   }
 `
 
-const StyledTable = styled(Table)`
+const StyledTable = styled.table`
   table-layout: fixed;
   width: 100%;
+  border-collapse: collapse;
 
   th,
   td {
@@ -33,16 +32,18 @@ const StyledTable = styled(Table)`
     overflow-wrap: break-word;
     hyphens: auto;
     padding: 8px;
+    text-align: left;
 
     color: var(--foreground) !important;
   }
 
   thead th {
-    border-bottom-color: var(--table-border) !important;
+    font-weight: 700;
+    border-bottom: 1px solid var(--table-border) !important;
   }
 
   tbody td {
-    border-top-color: var(--table-border) !important;
+    border-top: 1px solid var(--table-border) !important;
   }
 `
 
@@ -77,7 +78,6 @@ type SortableColumn = 'name' | 'privacy' | 'owner' | 'admins'
 const ListProjectTable: React.FC = () => {
   const auth = useAuth()
   const router = useRouter()
-  const isMobile = useMediaQuery('(max-width: 768px)')
   const [sortColumn, setSortColumn] = useState<SortableColumn>('name')
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
 
@@ -317,10 +317,8 @@ const ListProjectTable: React.FC = () => {
               </div>
             </>
           ) : (
-            <Text
-              size="md"
-              className={`pt-2 ${montserrat_heading.variable} font-montserratHeading`}
-              bg={'bg-transparent'}
+            <p
+              className={`pt-2 text-base ${montserrat_heading.variable} font-montserratHeading`}
               style={{
                 backgroundColor: 'transparent',
                 textAlign: 'center',
@@ -338,7 +336,7 @@ const ListProjectTable: React.FC = () => {
                 go make one here
               </Link>
               , don&apos;t worry it&apos;s easy.
-            </Text>
+            </p>
           )}
         </div>
       </>

--- a/apps/frontend/src/components/UIUC-Components/ProjectTable.tsx
+++ b/apps/frontend/src/components/UIUC-Components/ProjectTable.tsx
@@ -3,7 +3,14 @@ import { useMemo, useState } from 'react'
 import { type CourseMetadata } from '~/types/courseMetadata'
 import { isSuperAdmin } from '~/utils/superAdmins'
 import { useRouter } from 'next/router'
-import styled from 'styled-components'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/shadcn/ui/table'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import Link from 'next/link'
 import React from 'react'
@@ -14,63 +21,10 @@ import {
 } from '@tabler/icons-react'
 import { useQuery } from '@tanstack/react-query'
 
-const StyledRow = styled.tr`
-  &:hover {
-    color: var(--foreground);
-    background-color: var(--background-faded);
-  }
-`
-
-const StyledTable = styled.table`
-  table-layout: fixed;
-  width: 100%;
-  border-collapse: collapse;
-
-  th,
-  td {
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    hyphens: auto;
-    padding: 8px;
-    text-align: left;
-
-    color: var(--foreground) !important;
-  }
-
-  thead th {
-    font-weight: 700;
-    border-bottom: 1px solid var(--table-border) !important;
-  }
-
-  tbody td {
-    border-top: 1px solid var(--table-border) !important;
-  }
-`
-
-const ResponsiveTableWrapper = styled.div`
-  overflow-x: auto;
-  width: 100%;
-  color: var(--foreground);
-  background-color: var(--background);
-  border-radius: 15px;
-  padding: 0;
-
-  @media (min-width: 640px) {
-    padding: 0 8px;
-  }
-
-  @media (min-width: 768px) {
-    padding: 0 16px;
-  }
-
-  @media (min-width: 1024px) {
-    padding: 0 24px;
-  }
-
-  @media (min-width: 1280px) {
-    padding: 0 32px;
-  }
-`
+// Shared cell styling: keep the word-wrap/padding/color behavior of the
+// previous custom table (cells must wrap, fixed layout).
+const cellClasses =
+  'whitespace-normal break-words p-2 text-left text-[--foreground] [hyphens:auto]'
 
 type SortDirection = 'asc' | 'desc' | null
 type SortableColumn = 'name' | 'privacy' | 'owner' | 'admins'
@@ -194,11 +148,12 @@ const ListProjectTable: React.FC = () => {
         )
 
         return (
-          <StyledRow
+          <TableRow
             role="row"
             tabIndex={0}
             aria-label={courseName}
             key={courseName}
+            className="cursor-pointer border-[--table-border] hover:bg-[--background-faded] hover:text-[--foreground]"
             onClick={(e) => {
               // Check if cmd (Mac) or ctrl (Windows/Linux) key is pressed
               if (e.metaKey || e.ctrlKey) {
@@ -221,17 +176,21 @@ const ListProjectTable: React.FC = () => {
             }}
             style={{ cursor: 'pointer', color: 'var(--foreground)' }}
           >
-            <td>{courseName}</td>
-            <td>
+            <TableCell className={cellClasses}>{courseName}</TableCell>
+            <TableCell className={cellClasses}>
               {courseMetadata.is_private
                 ? courseMetadata.allow_logged_in_users
                   ? 'Logged-in Users'
                   : 'Private'
                 : 'Public'}
-            </td>
-            <td>{courseMetadata.course_owner}</td>
-            <td>{filteredAdmins.join(', ')}</td>
-          </StyledRow>
+            </TableCell>
+            <TableCell className={cellClasses}>
+              {courseMetadata.course_owner}
+            </TableCell>
+            <TableCell className={cellClasses}>
+              {filteredAdmins.join(', ')}
+            </TableCell>
+          </TableRow>
         )
       })
       .filter((row): row is JSX.Element => row !== null)
@@ -265,16 +224,19 @@ const ListProjectTable: React.FC = () => {
                   padding: '4px',
                 }}
               >
-                <StyledTable role="table" aria-label="Chatbots list">
-                  <thead>
-                    <tr>
+                <Table
+                  className="table-fixed text-base"
+                  aria-label="Chatbots list"
+                >
+                  <TableHeader>
+                    <TableRow className="border-[--table-border] hover:bg-transparent">
                       {[
                         { label: 'Chatbot Name', key: 'name' },
                         { label: 'Privacy', key: 'privacy' },
                         { label: 'Owner', key: 'owner' },
                         { label: 'Admins', key: 'admins' },
                       ].map(({ label, key }) => (
-                        <th
+                        <TableHead
                           key={key}
                           tabIndex={0}
                           aria-sort={
@@ -291,7 +253,7 @@ const ListProjectTable: React.FC = () => {
                               handleSort(key as SortableColumn)
                             }
                           }}
-                          style={{ cursor: 'pointer' }}
+                          className={`h-auto cursor-pointer font-bold ${cellClasses}`}
                         >
                           <div
                             style={{
@@ -308,12 +270,12 @@ const ListProjectTable: React.FC = () => {
                             </span>
                             {getSortIcon(key as SortableColumn)}
                           </div>
-                        </th>
+                        </TableHead>
                       ))}
-                    </tr>
-                  </thead>
-                  <tbody>{rows}</tbody>
-                </StyledTable>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>{rows}</TableBody>
+                </Table>
               </div>
             </>
           ) : (

--- a/apps/frontend/src/components/UIUC-Components/navbars/Navbar.tsx
+++ b/apps/frontend/src/components/UIUC-Components/navbars/Navbar.tsx
@@ -187,7 +187,7 @@ function NavigationContent({
         aria-label="Toggle Menu"
         aria-expanded={opened}
         onClick={onToggle}
-        className="p-1 text-[--foreground] [&_svg]:size-5 md:hidden"
+        className="p-1 text-[--foreground] md:hidden [&_svg]:size-5"
       >
         {opened ? (
           <IconX size={20} aria-hidden="true" />


### PR DESCRIPTION
## Summary

First **by-page** slice of the Mantine retirement (Illinois-Chat#45) — covers the **`/chatbots`** and **`/explore`** routes end-to-end, plus the shared **`PermissionGate`** error/access-gate that ~13 pages render (retired early so later slices inherit it). Stacked on #77 (slice 3).

4 files, +31 / −52.

### Changes
| File | Mantine removed | Approach |
|---|---|---|
| `Dashboard.tsx` | `Card`, `Title`, `useMediaQuery` | Card → bordered rounded `div`; Title → `<h1>` (kept explicit `text-2xl`); dropped unused `isSmallScreen` |
| `Explore.tsx` | `Card`, `useMediaQuery` | Card → bordered rounded `div`; dropped unused `isSmallScreen` |
| `PermissionGate.tsx` | `Button`, `Title`, `Flex`, `Text` | Flex → `flex` div; Title → `<h2>` **pinned to the theme's 2.2rem** heading size + `font-bold`; Text → `<p>`; Button → native `<button>` (styling was fully custom + daisyui `.btn`) |
| `ProjectTable.tsx` | `Table`, `Text`, `useMediaQuery` | `styled(Table)` → `styled.table`, **porting Mantine Table's base borders** (`border-collapse` + 1px header/row borders) and left-aligned cells so appearance is preserved; empty-state Text → `<p>`; dropped unused `isMobile` |

### Theme fidelity
Per the theme-overrides gotcha, headings without an explicit size class inherit the app's MantineProvider theme (`h1: 3rem`, `h2: 2.2rem`, Montserrat, bold). Dashboard's `<h1>` already had an explicit `text-2xl` so it's unchanged; PermissionGate's `<h2>` had no size class, so I pinned `text-[2.2rem] font-bold` to match. `ProjectTable`'s `styled(Table)` leaned on Mantine's base border widths (it only set border *colors*), so those are now declared explicitly.

### Verification
- `next build` (webpack): ✅ compiles
- `tsc --noEmit`: **110** (was 111 — removed a latent error: invalid `bg='bg-transparent'` on Mantine `Text`)
- `vitest run`: 244 files pass / 4 fail — the same 14 pre-existing env failures (#42 fixes those); the 3 affected tests (`Dashboard`, `ProjectTable`, `ProjectTable.a11y`) all pass unchanged
- `npm run lint`: 0 errors (18 pre-existing unused-var warnings in this dead-state boilerplate)

## Test plan
- [x] Suite/tsc/build/lint at or better than baseline
- [ ] TODO: visual spot-check `/chatbots` (table borders, "My Chatbots" heading, empty state) and `/explore` against production
- [ ] TODO: visual spot-check a `PermissionGate` screen (401/403/404) — heading size + button styling