### PR TITLE
refactor(frontend): retire Mantine from course dashboard page (slice 5)

### DIFF
--- a/apps/frontend/src/components/UIUC-Components/DocumentGroupsCard.tsx
+++ b/apps/frontend/src/components/UIUC-Components/DocumentGroupsCard.tsx
@@ -1,5 +1,3 @@
-import { ActionIcon, Card, Text, Title } from '@mantine/core'
-import { useMediaQuery } from '@mantine/hooks'
 import { IconInfoCircle } from '@tabler/icons-react'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -14,18 +12,14 @@ function DocumentGroupsCard({
   course_name: string
   sidebarCollapsed?: boolean
 }) {
-  const isSmallScreen = useMediaQuery('(max-width: 960px)')
   const [accordionOpened, setAccordionOpened] = useState(false)
 
   // Get responsive card width classes based on sidebar state
   const cardWidthClasses = useResponsiveCardWidth(sidebarCollapsed || false)
 
   return (
-    <Card
-      withBorder
-      padding="none"
-      radius="xl"
-      className={`mt-[2%] ${cardWidthClasses}`}
+    <div
+      className={`mt-[2%] ${cardWidthClasses} overflow-hidden rounded-[2rem] border`}
       style={{
         backgroundColor: 'var(--background)',
         borderColor: 'var(--dashboard-border)',
@@ -40,24 +34,22 @@ function DocumentGroupsCard({
         <div className="w-full border-b border-[--dashboard-border] px-4 py-3 sm:px-6 sm:py-4 md:px-8">
           <div className="flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-2">
-              <Title
-                order={3}
-                className={`${montserrat_heading.variable} font-montserratHeading text-lg text-[--foreground] sm:text-2xl`}
+              <h3
+                className={`${montserrat_heading.variable} font-montserratHeading text-lg font-bold text-[--foreground] sm:text-2xl`}
               >
                 Document Groups
-              </Title>
-              <ActionIcon
-                variant="subtle"
-                color="var(--foreground-faded)"
+              </h3>
+              <button
+                type="button"
                 onClick={() => setAccordionOpened(!accordionOpened)}
-                className="hover:bg-[--background]"
                 title="More info on document groups"
+                className="inline-flex items-center justify-center rounded-md p-1 hover:bg-[--background]"
               >
                 <IconInfoCircle
                   className="text-[--foreground-faded] hover:text-[--foreground]"
                   aria-hidden="true"
                 />
-              </ActionIcon>
+              </button>
             </div>
           </div>
         </div>
@@ -77,12 +69,12 @@ function DocumentGroupsCard({
                   <div
                     className={`${montserrat_paragraph.variable} mb-4 flex-1 p-4 font-montserratParagraph`}
                   >
-                    <Text
+                    <p
                       className={`${montserrat_paragraph.variable} mb-4 font-montserratParagraph text-[--foreground]`}
                     >
                       Document Groups help you organize and control your
                       content:
-                    </Text>
+                    </p>
                     <ul className="list-inside list-disc space-y-2 text-[--foreground]">
                       <li className="text-sm">
                         <span className="text-[--illinois-orange]">
@@ -112,7 +104,7 @@ function DocumentGroupsCard({
           <DocGroupsTable course_name={course_name} />
         </div>
       </div>
-    </Card>
+    </div>
   )
 }
 

--- a/apps/frontend/src/components/UIUC-Components/DocumentGroupsCard.tsx
+++ b/apps/frontend/src/components/UIUC-Components/DocumentGroupsCard.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/shadcn/ui/button'
+import { Card } from '@/components/shadcn/ui/card'
 import { IconInfoCircle } from '@tabler/icons-react'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -18,8 +20,8 @@ function DocumentGroupsCard({
   const cardWidthClasses = useResponsiveCardWidth(sidebarCollapsed || false)
 
   return (
-    <div
-      className={`mt-[2%] ${cardWidthClasses} overflow-hidden rounded-[2rem] border`}
+    <Card
+      className={`mt-[2%] ${cardWidthClasses} gap-0 rounded-[2rem] border py-0 text-base shadow-none ring-0`}
       style={{
         backgroundColor: 'var(--background)',
         borderColor: 'var(--dashboard-border)',
@@ -39,17 +41,19 @@ function DocumentGroupsCard({
               >
                 Document Groups
               </h3>
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="icon-sm"
                 onClick={() => setAccordionOpened(!accordionOpened)}
                 title="More info on document groups"
-                className="inline-flex items-center justify-center rounded-md p-1 hover:bg-[--background]"
+                className="hover:bg-[--background] [&_svg]:size-6"
               >
                 <IconInfoCircle
                   className="text-[--foreground-faded] hover:text-[--foreground]"
                   aria-hidden="true"
                 />
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -104,7 +108,7 @@ function DocumentGroupsCard({
           <DocGroupsTable course_name={course_name} />
         </div>
       </div>
-    </div>
+    </Card>
   )
 }
 

--- a/apps/frontend/src/components/UIUC-Components/DocumentsCard.tsx
+++ b/apps/frontend/src/components/UIUC-Components/DocumentsCard.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/shadcn/ui/button'
+import { Card } from '@/components/shadcn/ui/card'
 import {
   Dialog,
   DialogContent,
@@ -56,8 +58,8 @@ function DocumentsCard({
   }
 
   return (
-    <div
-      className={`mt-[2%] ${cardWidthClasses} overflow-hidden rounded-[2rem] border`}
+    <Card
+      className={`mt-[2%] ${cardWidthClasses} gap-0 rounded-[2rem] border py-0 text-base shadow-none ring-0`}
       style={{
         backgroundColor: 'var(--background)',
         borderColor: 'var(--dashboard-border)',
@@ -73,16 +75,18 @@ function DocumentsCard({
               {`Are you sure you want to export all the documents and embeddings?`}
             </p>
             <div className="mt-5 flex justify-end gap-2">
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 className="rounded-md bg-transparent text-white hover:bg-[--dashboard-button-hover]"
                 onClick={() => setExportModalOpened(false)}
               >
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
-                className="rounded-md bg-[--dashboard-button] text-[--dashboard-button-foreground] hover:bg-[--dashboard-button-hover]"
+                variant="dashboard"
+                className="rounded-md"
                 onClick={async () => {
                   setExportModalOpened(false)
                   const result = await handleExport(getCurrentPageName())
@@ -98,7 +102,7 @@ function DocumentsCard({
                 }}
               >
                 Export
-              </button>
+              </Button>
             </div>
           </DialogContent>
         </Dialog>
@@ -144,7 +148,7 @@ function DocumentsCard({
           )}
         </div>
       </div>
-    </div>
+    </Card>
   )
 }
 

--- a/apps/frontend/src/components/UIUC-Components/DocumentsCard.tsx
+++ b/apps/frontend/src/components/UIUC-Components/DocumentsCard.tsx
@@ -1,53 +1,38 @@
-import { Button, Card, Modal, Text, Title, createStyles } from '@mantine/core'
-import { useMediaQuery } from '@mantine/hooks'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/shadcn/ui/dialog'
 import { IconFileExport } from '@tabler/icons-react'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
+import styled from 'styled-components'
 import { handleExport } from '~/utils/handleExport'
 import { type CourseMetadata } from '~/types/courseMetadata'
 import { useResponsiveCardWidth } from '~/utils/responsiveGrid'
-import { showToastOnUpdate } from './MakeQueryAnalysisPage'
+import { showToast } from '~/utils/toastUtils'
 import { ProjectFilesTable } from './ProjectFilesTable'
 
-const useStyles = createStyles(() => ({
-  tabsList: {
-    borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-    padding: '0.5rem 2rem',
-    backgroundColor: 'rgba(0, 0, 0, 0.2)',
-    gap: '1rem',
-  },
-  tab: {
-    color: 'rgba(255, 255, 255, 0.9)',
-    '&[data-active]': {
-      backgroundColor: 'rgba(139, 92, 246, 0.3)',
-    },
-    '&:hover': {
-      backgroundColor: 'rgba(139, 92, 246, 0.2)',
-    },
-    borderRadius: '0.5rem',
-    padding: '0.5rem 1rem',
-  },
-  tableContainer: {
-    // backgroundColor: '#1e1f3a',
-    borderRadius: '0 0 0.75rem 0.75rem',
-    display: 'flex',
-    flexDirection: 'column',
-    flex: 1,
-    minHeight: 0,
-    '&::-webkit-scrollbar': {
-      width: '8px',
-    },
-    '&::-webkit-scrollbar-track': {
-      background: 'rgba(255, 255, 255, 0.1)',
-      borderRadius: '4px',
-    },
-    '&::-webkit-scrollbar-thumb': {
-      background: 'rgba(139, 92, 246, 0.5)',
-      borderRadius: '4px',
-    },
-  },
-}))
+const TableContainer = styled.div`
+  border-radius: 0 0 0.75rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  &::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(139, 92, 246, 0.5);
+    border-radius: 4px;
+  }
+`
 
 function DocumentsCard({
   course_name,
@@ -60,10 +45,8 @@ function DocumentsCard({
 }) {
   const [tabValue, setTabValue] = useState<string | null>('success')
   const [failedCount, setFailedCount] = useState<number>(0)
-  const isSmallScreen = useMediaQuery('(max-width: 960px)')
   const [exportModalOpened, setExportModalOpened] = useState(false)
   const router = useRouter()
-  const { classes, theme } = useStyles()
 
   // Get responsive card width classes based on sidebar state
   const cardWidthClasses = useResponsiveCardWidth(sidebarCollapsed || false)
@@ -73,56 +56,60 @@ function DocumentsCard({
   }
 
   return (
-    <Card
-      withBorder
-      padding="none"
-      radius="xl"
-      className={`mt-[2%] ${cardWidthClasses}`}
+    <div
+      className={`mt-[2%] ${cardWidthClasses} overflow-hidden rounded-[2rem] border`}
       style={{
         backgroundColor: 'var(--background)',
         borderColor: 'var(--dashboard-border)',
       }}
     >
       <div className="min-h-full bg-[--background]">
-        <Modal
-          opened={exportModalOpened}
-          onClose={() => setExportModalOpened(false)}
-          title="Please confirm your action"
-          centered
-        >
-          <Text size="sm" style={{ color: 'white' }}>
-            {`Are you sure you want to export all the documents and embeddings?`}
-          </Text>
-          <div className="mt-5 flex justify-end gap-2">
-            <Button
-              className="rounded-md bg-transparent text-white hover:bg-[--dashboard-button-hover]"
-              onClick={() => setExportModalOpened(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              className="rounded-md bg-[--dashboard-button] text-[--dashboard-button-foreground] hover:bg-[--dashboard-button-hover]"
-              onClick={async () => {
-                setExportModalOpened(false)
-                const result = await handleExport(getCurrentPageName())
-                if (result && result.message) {
-                  showToastOnUpdate(theme, false, false, result.message)
-                }
-              }}
-            >
-              Export
-            </Button>
-          </div>
-        </Modal>
+        <Dialog open={exportModalOpened} onOpenChange={setExportModalOpened}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Please confirm your action</DialogTitle>
+            </DialogHeader>
+            <p className="text-sm" style={{ color: 'white' }}>
+              {`Are you sure you want to export all the documents and embeddings?`}
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded-md bg-transparent text-white hover:bg-[--dashboard-button-hover]"
+                onClick={() => setExportModalOpened(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="rounded-md bg-[--dashboard-button] text-[--dashboard-button-foreground] hover:bg-[--dashboard-button-hover]"
+                onClick={async () => {
+                  setExportModalOpened(false)
+                  const result = await handleExport(getCurrentPageName())
+                  if (result && result.message) {
+                    showToast({
+                      autoClose: 30000,
+                      title: result.message,
+                      message:
+                        'Check our docs (https://docs.uiuc.chat/features/bulk-export-documents-or-conversation-history) for example code to process this data.',
+                      type: 'success',
+                    })
+                  }
+                }}
+              >
+                Export
+              </button>
+            </div>
+          </DialogContent>
+        </Dialog>
 
         <div className="w-full border-b border-[--dashboard-border] px-4 py-3 sm:px-6 sm:py-4 md:px-8">
           <div className="flex items-center justify-between gap-2">
-            <Title
-              order={3}
-              className={`${montserrat_heading.variable} font-montserratHeading text-lg text-[--foreground] sm:text-2xl`}
+            <h3
+              className={`${montserrat_heading.variable} font-montserratHeading text-lg font-bold text-[--foreground] sm:text-2xl`}
             >
               Project Files
-            </Title>
+            </h3>
             {/*FIXME: Export temporarily disabled because chunks larger than 200 MB aren’t stored in the database.*/}
             {/*<Button*/}
             {/*  variant="subtle"*/}
@@ -145,7 +132,7 @@ function DocumentsCard({
 
         <div className="bg-[--background] text-[--foreground]">
           {metadata && (
-            <div className={classes.tableContainer}>
+            <TableContainer>
               <ProjectFilesTable
                 course_name={course_name}
                 setFailedCount={setFailedCount}
@@ -153,11 +140,11 @@ function DocumentsCard({
                 onTabChange={(value) => setTabValue(value)}
                 failedCount={failedCount}
               />
-            </div>
+            </TableContainer>
           )}
         </div>
       </div>
-    </Card>
+    </div>
   )
 }
 

--- a/apps/frontend/src/components/UIUC-Components/MakeOldCoursePage.tsx
+++ b/apps/frontend/src/components/UIUC-Components/MakeOldCoursePage.tsx
@@ -1,4 +1,3 @@
-import { Flex } from '@mantine/core'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
@@ -92,7 +91,7 @@ const MakeOldCoursePage = ({
       >
         <h1 className="sr-only">{course_name} Dashboard</h1>
         <div className="items-left flex w-full flex-col justify-center py-0">
-          <Flex direction="column" align="center" w="100%">
+          <div className="flex w-full flex-col items-center">
             {/* Upload Card Section */}
             <UploadCard
               projectName={course_name}
@@ -115,7 +114,7 @@ const MakeOldCoursePage = ({
             />
 
             {/* <NomicDocumentsCard course_name={course_name} metadata={metadata} /> */}
-          </Flex>
+          </div>
         </div>
       </main>
 

--- a/apps/frontend/src/components/UIUC-Components/UploadCard.tsx
+++ b/apps/frontend/src/components/UIUC-Components/UploadCard.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/shadcn/ui/button'
+import { Card } from '@/components/shadcn/ui/card'
 import { Textarea } from '@/components/shadcn/ui/textarea'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import {
@@ -88,8 +90,8 @@ export const UploadCard = memo(function UploadCard({
     setUploadFiles(updateFn)
   }
   return (
-    <div
-      className={`mt-[2%] ${cardWidthClasses} overflow-hidden rounded-[2rem] border`}
+    <Card
+      className={`mt-[2%] ${cardWidthClasses} gap-0 rounded-[2rem] border py-0 text-base shadow-none ring-0`}
       style={{
         backgroundColor: 'var(--background)',
         borderColor: 'var(--dashboard-border)',
@@ -127,10 +129,11 @@ export const UploadCard = memo(function UploadCard({
               </div>
 
               <div className="-inset-0.25 relative shrink-0 rounded-3xl p-0.5">
-                <button
+                <Button
                   type="button"
+                  variant="dashboard"
                   onClick={() => setIsShareModalOpen(true)}
-                  className={`relative transform rounded-3xl bg-[--dashboard-button] text-[--dashboard-button-foreground] hover:bg-[--dashboard-button-hover] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[--dashboard-button] ${montserrat_paragraph.variable} min-h-[2rem] px-2 font-montserratParagraph text-sm sm:min-h-[2.5rem] sm:px-4 sm:text-base`}
+                  className={`relative h-auto transform rounded-3xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[--dashboard-button] ${montserrat_paragraph.variable} min-h-[2rem] px-2 font-montserratParagraph text-sm font-normal sm:min-h-[2.5rem] sm:px-4 sm:text-base`}
                 >
                   <span className="hidden sm:inline">Sharing and Access</span>
                   <span className="inline sm:hidden">Access</span>
@@ -144,7 +147,7 @@ export const UploadCard = memo(function UploadCard({
                     className="ml-2 hidden sm:inline"
                     aria-hidden="true"
                   />
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -217,10 +220,11 @@ export const UploadCard = memo(function UploadCard({
                 onChange={(e) => setProjectDescription(e.target.value)}
                 className={`${montserrat_paragraph.variable} min-h-[7rem] bg-[--background] font-montserratParagraph text-base text-[--foreground]`}
               />
-              <button
+              <Button
                 type="button"
+                variant="dashboard"
                 tabIndex={0}
-                className="mt-3 w-24 self-end bg-[--dashboard-button] text-[--dashboard-button-foreground] hover:bg-[--dashboard-button-hover]"
+                className="mt-3 w-24 self-end"
                 onClick={async () => {
                   if (metadata) {
                     metadata.project_description = projectDescription
@@ -238,7 +242,7 @@ export const UploadCard = memo(function UploadCard({
                 }}
               >
                 Update
-              </button>
+              </Button>
             </div>
 
             <div className="space-y-2">
@@ -274,9 +278,10 @@ export const UploadCard = memo(function UploadCard({
                 />
                 {isIntroMessageUpdated && (
                   <>
-                    <button
+                    <Button
+                      variant="dashboard"
                       tabIndex={0}
-                      className="relative m-1 w-[30%] self-end bg-[--dashboard-button] text-[--dashboard-button-foreground] hover:bg-[--dashboard-button-hover]"
+                      className="relative m-1 w-[30%] self-end"
                       type="submit"
                       onClick={async () => {
                         setIsIntroMessageUpdated(false)
@@ -298,7 +303,7 @@ export const UploadCard = memo(function UploadCard({
                       }}
                     >
                       Submit
-                    </button>
+                    </Button>
                   </>
                 )}
               </div>
@@ -377,6 +382,6 @@ export const UploadCard = memo(function UploadCard({
           course_admins: metadata.course_admins || [],
         }}
       />
-    </div>
+    </Card>
   )
 })

--- a/apps/frontend/src/components/UIUC-Components/UploadCard.tsx
+++ b/apps/frontend/src/components/UIUC-Components/UploadCard.tsx
@@ -1,14 +1,4 @@
-import {
-  Button,
-  Card,
-  createStyles,
-  Flex,
-  SimpleGrid,
-  Text,
-  Textarea,
-  Title,
-} from '@mantine/core'
-import { useMediaQuery } from '@mantine/hooks'
+import { Textarea } from '@/components/shadcn/ui/textarea'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import {
   type CourseMetadata,
@@ -38,51 +28,6 @@ const montserrat_light = Montserrat({
   subsets: ['latin'],
 })
 
-const useStyles = createStyles((theme) => ({
-  // For Accordion
-  root: {
-    padding: 0,
-    borderRadius: theme.radius.xl,
-    outline: 'none',
-  },
-  switch: {
-    color: 'var(--dashboard-button-foreground)',
-    backgroundColor: 'var(--dashboard-button)',
-    input: {
-      color: 'var(--foreground)',
-      backgroundColor: 'var(--background)',
-    },
-    root: {
-      color: 'var(--foreground)',
-      backgroundColor: 'var(--background)',
-    },
-  },
-  item: {
-    backgroundColor: 'bg-transparent',
-    border: `solid transparent`,
-    borderRadius: theme.radius.xl,
-    position: 'relative',
-    zIndex: 0,
-    transition: 'transform 150ms ease',
-    outline: 'none',
-
-    '&[data-active]': {
-      transform: 'scale(1.03)',
-      backgroundColor: 'bg-transparent',
-      zIndex: 1,
-    },
-    '&:hover': {
-      backgroundColor: 'bg-transparent',
-    },
-  },
-
-  chevron: {
-    '&[data-rotate]': {
-      transform: 'rotate(90deg)',
-    },
-  },
-}))
-
 export const UploadCard = memo(function UploadCard({
   projectName,
   current_user_email,
@@ -95,7 +40,6 @@ export const UploadCard = memo(function UploadCard({
   sidebarCollapsed?: boolean
 }) {
   const auth = useAuth()
-  const isSmallScreen = useMediaQuery('(max-width: 960px)')
 
   // Get responsive card width classes based on sidebar state
   const cardWidthClasses = useResponsiveCardWidth(sidebarCollapsed || false)
@@ -144,17 +88,14 @@ export const UploadCard = memo(function UploadCard({
     setUploadFiles(updateFn)
   }
   return (
-    <Card
-      withBorder
-      padding="none"
-      radius="xl"
-      className={`mt-[2%] ${cardWidthClasses}`}
+    <div
+      className={`mt-[2%] ${cardWidthClasses} overflow-hidden rounded-[2rem] border`}
       style={{
         backgroundColor: 'var(--background)',
         borderColor: 'var(--dashboard-border)',
       }}
     >
-      <Flex direction={isSmallScreen ? 'column' : 'row'}>
+      <div className="flex flex-col min-[960px]:flex-row">
         <div
           style={{
             flex: '1 1 95%',
@@ -166,31 +107,28 @@ export const UploadCard = memo(function UploadCard({
           <div className="w-full border-b border-[--dashboard-border] px-4 py-3 sm:px-6 sm:py-4 md:px-8">
             <div className="flex items-center justify-between gap-2">
               <div className="flex min-w-0 flex-wrap items-center gap-2">
-                <Title
-                  order={2}
-                  className={`${montserrat_heading.variable} font-montserratHeading text-lg text-[--foreground] sm:text-2xl`}
+                <h2
+                  className={`${montserrat_heading.variable} font-montserratHeading text-lg font-bold text-[--foreground] sm:text-2xl`}
                 >
                   Dashboard
-                </Title>
-                <Text className="text-[--foreground]">/</Text>
-                <Title
-                  order={3}
+                </h2>
+                <span className="text-[--foreground]">/</span>
+                <h3
                   className={`${
                     montserrat_heading.variable
-                  } min-w-0 font-montserratHeading text-base text-[--illinois-orange] sm:text-xl ${
+                  } min-w-0 font-montserratHeading text-base font-bold text-[--illinois-orange] sm:text-xl ${
                     projectName.length > 40
                       ? 'max-w-[120px] truncate sm:max-w-[300px] lg:max-w-[400px]'
                       : ''
                   }`}
                 >
                   {projectName}
-                </Title>
+                </h3>
               </div>
 
               <div className="-inset-0.25 relative shrink-0 rounded-3xl p-0.5">
-                <Button
-                  variant="subtle"
-                  size="xs"
+                <button
+                  type="button"
                   onClick={() => setIsShareModalOpen(true)}
                   className={`relative transform rounded-3xl bg-[--dashboard-button] text-[--dashboard-button-foreground] hover:bg-[--dashboard-button-hover] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[--dashboard-button] ${montserrat_paragraph.variable} min-h-[2rem] px-2 font-montserratParagraph text-sm sm:min-h-[2.5rem] sm:px-4 sm:text-base`}
                 >
@@ -206,7 +144,7 @@ export const UploadCard = memo(function UploadCard({
                     className="ml-2 hidden sm:inline"
                     aria-hidden="true"
                   />
-                </Button>
+                </button>
               </div>
             </div>
           </div>
@@ -224,15 +162,7 @@ export const UploadCard = memo(function UploadCard({
             />
           </div>
 
-          <SimpleGrid
-            cols={3}
-            spacing="lg"
-            breakpoints={[
-              { maxWidth: 1192, cols: 2, spacing: 'md' },
-              { maxWidth: 768, cols: 1, spacing: 'sm' },
-            ]}
-            className="px-4 py-4 sm:px-6 sm:py-6 md:px-8"
-          >
+          <div className="grid grid-cols-1 gap-3 px-4 py-4 sm:px-6 sm:py-6 md:grid-cols-2 md:gap-4 md:px-8 min-[1192px]:grid-cols-3 min-[1192px]:gap-5">
             <CanvasIngestForm
               project_name={projectName}
               setUploadFiles={handleSetUploadFiles}
@@ -258,7 +188,7 @@ export const UploadCard = memo(function UploadCard({
             />
 
             <CourseraIngestForm />
-          </SimpleGrid>
+          </div>
           <UploadNotification
             files={uploadFiles}
             onClose={handleCloseNotification}
@@ -268,42 +198,27 @@ export const UploadCard = memo(function UploadCard({
 
         <div
           style={{
-            flex: isSmallScreen ? '1 1 100%' : '1 1 40%',
             backgroundColor: 'var(--dashboard-sidebar-background)',
             color: 'var(--dashboard-foreground)',
-            borderLeft: isSmallScreen
-              ? ''
-              : '1px solid var(--dashboard-border)',
           }}
-          className="p-4 sm:p-6"
+          className="flex-[1_1_100%] p-4 sm:p-6 min-[960px]:flex-[1_1_40%] min-[960px]:border-l min-[960px]:border-[--dashboard-border]"
         >
           <div className="card flex h-full flex-col justify-start space-y-6">
             <div className="form-control">
-              <Title
-                className={`${montserrat_heading.variable} mb-4 font-montserratHeading text-[--dashboard-foreground]`}
-                order={3}
+              <h3
+                className={`${montserrat_heading.variable} mb-4 font-montserratHeading text-[1.375rem] font-bold text-[--dashboard-foreground]`}
               >
                 Project Description
-              </Title>
+              </h3>
               <Textarea
                 placeholder="Describe your project, goals, expected impact etc..."
                 aria-label="Project Description"
-                radius={'sm'}
                 value={projectDescription}
                 onChange={(e) => setProjectDescription(e.target.value)}
-                size={'lg'}
-                minRows={4}
-                styles={{
-                  input: {
-                    color: 'var(--foreground)',
-                    backgroundColor: 'var(--background)',
-                    fontSize: '16px',
-                    font: `${montserrat_paragraph.variable} font-montserratParagraph`,
-                  },
-                }}
-                className={`${montserrat_paragraph.variable} font-montserratParagraph`}
+                className={`${montserrat_paragraph.variable} min-h-[7rem] bg-[--background] font-montserratParagraph text-base text-[--foreground]`}
               />
-              <Button
+              <button
+                type="button"
                 tabIndex={0}
                 className="mt-3 w-24 self-end bg-[--dashboard-button] text-[--dashboard-button-foreground] hover:bg-[--dashboard-button-hover]"
                 onClick={async () => {
@@ -323,16 +238,15 @@ export const UploadCard = memo(function UploadCard({
                 }}
               >
                 Update
-              </Button>
+              </button>
             </div>
 
             <div className="space-y-2">
-              <Title
-                className={`${montserrat_heading.variable} font-montserratHeading text-[--dashboard-foreground]`}
-                order={3}
+              <h3
+                className={`${montserrat_heading.variable} font-montserratHeading text-[1.375rem] font-bold text-[--dashboard-foreground]`}
               >
                 Branding
-              </Title>
+              </h3>
 
               <div className="form-control relative">
                 <label
@@ -343,25 +257,15 @@ export const UploadCard = memo(function UploadCard({
                     Set a greeting
                   </span>
                 </label>
-                <Text
-                  className={`label ${montserrat_light.className} pt-0`}
-                  size={'sm'}
+                <p
+                  className={`label ${montserrat_light.className} pt-0 text-sm`}
                 >
                   Shown before users send their first chat.
-                </Text>
+                </p>
                 <Textarea
                   id="greeting-textarea"
-                  autosize
-                  minRows={2}
-                  maxRows={4}
                   placeholder="Enter a greeting to help users get started with your bot"
-                  className={`w-full ${montserrat_paragraph.variable} font-montserratParagraph`}
-                  styles={{
-                    input: {
-                      color: 'var(--foreground)',
-                      backgroundColor: 'var(--background)',
-                    },
-                  }}
+                  className={`w-full ${montserrat_paragraph.variable} max-h-[7rem] min-h-[3.5rem] bg-[--background] font-montserratParagraph text-[--foreground]`}
                   value={introMessage}
                   onChange={(e) => {
                     setIntroMessage(e.target.value)
@@ -370,7 +274,7 @@ export const UploadCard = memo(function UploadCard({
                 />
                 {isIntroMessageUpdated && (
                   <>
-                    <Button
+                    <button
                       tabIndex={0}
                       className="relative m-1 w-[30%] self-end bg-[--dashboard-button] text-[--dashboard-button-foreground] hover:bg-[--dashboard-button-hover]"
                       type="submit"
@@ -394,7 +298,7 @@ export const UploadCard = memo(function UploadCard({
                       }}
                     >
                       Submit
-                    </Button>
+                    </button>
                   </>
                 )}
               </div>
@@ -405,13 +309,12 @@ export const UploadCard = memo(function UploadCard({
                   Set example questions
                 </span>
               </p>
-              <Text
-                className={`label !mt-0 ${montserrat_light.className} pb-0`}
-                mb={-3}
-                size={'sm'}
+              <p
+                className={`label !mt-0 ${montserrat_light.className} pb-0 text-sm`}
+                style={{ marginBottom: '-3px' }}
               >
                 Users will likely try these first to get a feel for your bot.
-              </Text>
+              </p>
               <SetExampleQuestions
                 course_name={projectName}
                 course_metadata={metadata as CourseMetadataOptionalForUpsert}
@@ -425,12 +328,11 @@ export const UploadCard = memo(function UploadCard({
                     Upload your logo
                   </span>
                 </label>
-                <Text
-                  size={'sm'}
-                  className={`label !mt-0 ${montserrat_light.className}`}
+                <p
+                  className={`label !mt-0 ${montserrat_light.className} text-sm`}
                 >
                   This logo will appear in the header of the chat page.
-                </Text>
+                </p>
                 <input
                   id="upload-logo-input"
                   tabIndex={0}
@@ -464,7 +366,7 @@ export const UploadCard = memo(function UploadCard({
             </div>
           </div>
         </div>
-      </Flex>
+      </div>
       <ShareSettingsModal
         opened={isShareModalOpen}
         onClose={() => setIsShareModalOpen(false)}
@@ -475,6 +377,6 @@ export const UploadCard = memo(function UploadCard({
           course_admins: metadata.course_admins || [],
         }}
       />
-    </Card>
+    </div>
   )
 })


### PR DESCRIPTION
## Summary

By-page slice of the Mantine retirement (Illinois-Chat#45) — covers the **`/[course_name]/dashboard`** route end-to-end (its 4 components). Stacked on #78 (slice 4). 4 files, +128 / −248.

### Changes
| File | Mantine removed | Approach |
|---|---|---|
| `MakeOldCoursePage.tsx` | `Flex` | → flex `div` |
| `DocumentGroupsCard.tsx` | `Card`, `ActionIcon`, `Text`, `Title`, `useMediaQuery` | Card→bordered rounded div; Title→`<h3>`; ActionIcon info-toggle→native `<button>` (keeps `title` + `onClick`); Text→`<p>`; dropped unused `isSmallScreen` |
| `DocumentsCard.tsx` | `Button`, `Card`, `Modal`, `Text`, `Title`, `createStyles`, `useMediaQuery` | Card→div; **Modal→shadcn Dialog**; `createStyles`→a `styled.div` (`TableContainer`, incl. the custom webkit scrollbar); Title→`<h3>`; dropped unused `isSmallScreen` |
| `UploadCard.tsx` | `Button`, `Card`, `createStyles`, `Flex`, `SimpleGrid`, `Text`, `Textarea`, `Title`, `useMediaQuery` | deleted dead `createStyles` block; Card→div; `Flex`+`isSmallScreen(960px)` branches→Tailwind `min-[960px]:*`; `SimpleGrid`→Tailwind grid; 2 Textareas→**shadcn Textarea** (autosizes via `field-sizing-content`); 3 Buttons→native; headings→`h2`/`h3`; Text→`p`/`span` |

### Notable decisions
- **Dropped a cross-slice coupling:** `DocumentsCard` called `showToastOnUpdate(theme, …)` from `MakeQueryAnalysisPage` (a slice-7 file) purely to pass a `MantineTheme`. Since that helper is now just a thin `showToast` wrapper (its `theme`/`was_error`/`isReset` args are unused) **and** the export UI that triggers it is commented-out/disabled, I replaced the call with a direct `showToast({…})` (sonner). No behavior change; removes the Mantine `theme` dependency.
- **Theme fidelity:** headings without an explicit size class were pinned to the app theme (`h2`=2.2rem, `h3`=1.375rem, Mantine's bold weight) so nothing shrinks under Tailwind preflight.
- **Textarea autosize** preserved for free — shadcn `ui/textarea` uses `field-sizing-content`.

### Verification
- `next build` (webpack): ✅ compiles
- `tsc --noEmit`: **110**, unchanged baseline, 0 new
- `vitest run`: 244 pass / 4 fail — the same 14 pre-existing env failures (#42); the 2 affected tests (`DocumentGroupsCard`, `UploadCard`, 15 tests) pass unchanged
- `npm run lint`: 0 errors (5 pre-existing unused-var warnings, incl. `IconFileExport`/`montserrat_paragraph` referenced only in commented-out disabled-export code)

## Test plan
- [x] Suite/tsc/build/lint at or better than baseline
- [ ] TODO: visual spot-check `/[course]/dashboard` — the three cards (borders/radius), headings, the two textareas (autosize + colors), and the SimpleGrid→grid ingest-form layout at the 768/1192px breakpoints
- [ ] TODO: the export confirmation Dialog is disabled UI (trigger commented out); if re-enabled later, verify the shadcn Dialog styling