### PR TITLE
Crawler ingest hardening: browser launch fix, PDF guards, error-page filtering

### DIFF
--- a/apps/crawlee/Dockerfile
+++ b/apps/crawlee/Dockerfile
@@ -21,6 +21,15 @@ RUN npm run build
 # Create final image
 FROM apify/actor-node-playwright-chrome:20
 
+# Install the browser into a runtime-user-writable path. The base image bundles a
+# chromium that matches ITS playwright (1.60); our package.json pins playwright
+# 1.42.1, which expects a different chromium revision than the one at the root-owned
+# /pw-browsers, so the bundled browser is unusable and the launch fails with
+# BrowserLaunchError. Pointing PLAYWRIGHT_BROWSERS_PATH at a myuser-owned dir lets us
+# install the chromium that matches our pinned playwright (no EACCES, no --with-deps:
+# the base image already carries chromium's system libraries).
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/myuser/pw-browsers
+
 # Copy only built JS files from builder image
 COPY --from=builder --chown=myuser /home/myuser/dist ./dist
 
@@ -39,6 +48,9 @@ RUN npm --quiet set progress=false \
     && node --version \
     && echo "NPM version:" \
     && npm --version
+
+# Install the chromium build matching the pinned playwright into the writable path.
+RUN npx playwright install chromium
 
 # Next, copy the remaining files and directories with the source code.
 # Since we do this after NPM install, quick build will be really fast

--- a/apps/crawlee/src/api/crawlee.ts
+++ b/apps/crawlee/src/api/crawlee.ts
@@ -1,8 +1,6 @@
 // For more information, see https://crawlee.dev/
 import { Configuration, PlaywrightCrawler, downloadListOfUrls } from "crawlee";
 import { Page } from "playwright";
-import axios from "axios";
-// import { isWithinTokenLimit } from "gpt-tokenizer";
 
 import { Config, configSchema } from "./configValidation.js";
 import { ingestPdf, uploadPdfToS3 } from "./uploadToS3.js";
@@ -12,8 +10,6 @@ export async function crawl(rawConfig: Config) {
   console.log("PARSED, final config:", config);
 
   let pageCounter = 0;
-  const ingestionPromises: Promise<any>[] = [];
-  // const results: Array<{ title: string; url: string; html: string }> = [];
 
   if (config.url) {
     console.log(`Crawling URL: ${config.url}`);
@@ -37,7 +33,7 @@ export async function crawl(rawConfig: Config) {
 
             // Use the requestHandler to process each of the crawled pages.
             // removed , pushData from params... weird try catch behavior
-            async requestHandler({ request, page, enqueueLinks, log }) {
+            async requestHandler({ request, response, page, enqueueLinks, log }) {
               console.log(`Crawling: ${request.loadedUrl}...`);
               const title = await page.title();
               pageCounter++;
@@ -67,19 +63,17 @@ export async function crawl(rawConfig: Config) {
 
               // Grab results from the page
               if (request.loadedUrl) {
-                // results.push({ title, url: request.loadedUrl, html });
-
-                // TODO: handle all file types (this is probably better than the transform function below)
-                // TODO: NOOO Do it below instead, otherwise the match strategy never makes it here!!
-                // const validFiletypes = ['.html', '.py', '.vtt', '.pdf', '.txt', '.srt', '.docx', '.ppt', '.pptx']
-                // if (validFiletypes.some(ext => req.url.endsWith(ext))) {
-                //   // If URL is a file, send it to handleFile
-                //   handleFile(req.url, config.courseName);
-                //   return null; // Returning null will prevent the URL from being enqueued
-                // }
-
-                // Asynchronously call the ingestWebscrape endpoint without awaiting the result
-                if (html) {
+                // Asynchronously call the ingestWebscrape endpoint without awaiting the result.
+                // Skip error/empty pages (soft-404s, dead links, paywalls) so they never enter
+                // the corpus. The ingest POST is fire-and-forget, so we log every skip with a
+                // greppable SKIP-INGEST prefix to keep the pipeline monitorable from the logs.
+                const skipReason = shouldSkipIngest(title, html, response?.status());
+                if (skipReason) {
+                  console.warn(
+                    `SKIP-INGEST (${skipReason}): status=${response?.status() ?? "n/a"} ` +
+                      `base_url=${config.url} url=${request.loadedUrl} title=${JSON.stringify(title)}`,
+                  );
+                } else {
                   const ingestUrl = process.env.INGEST_URL;
 
                   if (!ingestUrl) {
@@ -103,38 +97,12 @@ export async function crawl(rawConfig: Config) {
                       content: html,
                       course_name: config.courseName,
                       groups: config.documentGroups,
-                      // s3_paths: s3Key,
                     }),
                   })
                     .then((response) => response.text())
-                    // .then(text => {
-                    //   console.log(`In success case -- Data ingested for URL: ${request.loadedUrl}`);
-                    //   console.log(text)
-                    // })
                     .catch((err) => console.error(err));
-
-                  // ingestionPromises.push(
-                  //   axios.post('https://flask-production-751b.up.railway.app/ingest-web-text', {
-                  //     base_url: config.url,
-                  //     url: request.loadedUrl,
-                  //     title: title,
-                  //     content: html,
-                  //     courseName: config.courseName,
-                  //   }).then(() => {
-                  //     console.log(`Data ingested for URL: ${request.loadedUrl}`);
-                  //   }).catch(error => {
-                  //     console.error(`Failed to ingest data for URL: ${request.loadedUrl}`, error.name, error.message, error.data);
-                  //   })
-                  // )
-                } else {
-                  console.error("Error: URL is undefined. Title is: ", title);
                 }
               }
-
-              // Disabled this due to weird type error all of a sudden, after adding the try catch
-              // if (config.onVisitPage) {
-              //   await config.onVisitPage({ page, pushData });
-              // }
 
               page.off("console", consoleListener); // remove listener to avoid memory leak
 
@@ -267,12 +235,67 @@ export async function crawl(rawConfig: Config) {
       }
     }
   }
-  // Before returning from the function, wait for all the ingestion promises to resolve
-  await Promise.all(ingestionPromises);
   return pageCounter;
 }
 
 // ----- HELPERS -----
+
+// Page titles that almost always indicate an error/placeholder page rather than real
+// content (matched case-insensitively against the page <title>). Soft-404s commonly
+// return HTTP 200 with one of these titles, so the title is the reliable signal.
+const ERROR_TITLE_PATTERNS: RegExp[] = [
+  /\b(404|403|410)\b/,
+  /page not found/i,
+  /\bnot found\b/i,
+  /error\s*[: ]?\s*40\d/i,
+  /\bforbidden\b/i,
+  /access denied/i,
+  /document not found/i,
+  /no longer (available|exists)/i,
+  /(temporarily|service|currently) unavailable/i,
+  /site (can.?t|cannot) be reached/i,
+  /account suspended/i,
+  /under construction/i,
+  /\b410 gone\b/i,
+];
+
+// Body-text phrases that indicate an error page. Trusted only on SHORT pages — real
+// articles are long and may legitimately mention these phrases, so we bound the
+// false-positive risk by length rather than dropping content matching entirely.
+const ERROR_CONTENT_PATTERNS: RegExp[] = [
+  /the page you (requested|are looking for) (could not be|was not|cannot be|can.?t be) found/i,
+  /the requested url .{0,40} was not found on this server/i,
+  /this page (doesn.?t|does not) exist/i,
+  /we can.?t find the page/i,
+  /sorry,? (this|the) page/i,
+  /page not found/i,
+];
+
+const MIN_CONTENT_CHARS = 30; // trimmed body shorter than this == effectively empty
+const SHORT_CONTENT_CHARS = 350; // only trust ERROR_CONTENT_PATTERNS on pages this short
+
+// Decide whether a crawled page should be SKIPPED (not POSTed to the ingest endpoint).
+// Returns a short reason string when it should be skipped, or null for good content.
+// Catches: empty pages, hard HTTP 4xx/5xx, soft-404s (HTTP 200 + error title), and short
+// error-page bodies. Logged by the caller with a greppable SKIP-INGEST prefix.
+function shouldSkipIngest(
+  title: string,
+  content: string,
+  status?: number,
+): string | null {
+  const text = (content ?? "").trim();
+  if (text.length < MIN_CONTENT_CHARS) return "empty-content";
+  if (typeof status === "number" && status >= 400) return `http-${status}`;
+  const t = (title ?? "").trim();
+  if (t && ERROR_TITLE_PATTERNS.some((re) => re.test(t))) return "error-title";
+  if (
+    text.length <= SHORT_CONTENT_CHARS &&
+    ERROR_CONTENT_PATTERNS.some((re) => re.test(text))
+  ) {
+    return "error-content";
+  }
+  return null;
+}
 
 async function handlePdf(
   courseName: string,
@@ -282,6 +305,7 @@ async function handlePdf(
 ) {
   try {
     const s3Key = await uploadPdfToS3(url, courseName);
+    if (!s3Key) return; // URL didn't serve a real PDF (redirected to HTML) — skip ingest
     await new Promise((resolve) => setTimeout(resolve, 3000));
     await ingestPdf(s3Key, courseName, base_url, url, documentGroups);
   } catch (error) {

--- a/apps/crawlee/src/api/uploadToS3.ts
+++ b/apps/crawlee/src/api/uploadToS3.ts
@@ -1,7 +1,7 @@
 // upload.ts
 import * as path from 'path';
 import axios from 'axios';
-import { S3Client, PutObjectCommand, HeadBucketCommand, CreateBucketCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, HeadObjectCommand, HeadBucketCommand, CreateBucketCommand } from '@aws-sdk/client-s3';
 
 function createS3Client(): S3Client {
   const region = process.env.AWS_REGION
@@ -30,8 +30,10 @@ if (!s3BucketName) {
   console.error('❌ Missing S3_BUCKET_NAME in environment!')
 }
 
-// Upload PDF to S3 and send the S3 path to the ingest function
-export async function uploadPdfToS3(url: string, courseName: string) {
+// Upload PDF to S3 and send the S3 path to the ingest function.
+// Returns the S3 key, or null when the URL did not actually serve a PDF (so the caller
+// can skip ingest instead of pushing a broken document into the pipeline).
+export async function uploadPdfToS3(url: string, courseName: string): Promise<string | null> {
   const s3Client = createS3Client()
 
   // Sanitize filename
@@ -39,6 +41,20 @@ export async function uploadPdfToS3(url: string, courseName: string) {
   const extension = path.extname(humanURI);
   const nameWithoutExtension = path.basename(humanURI, extension);
   const filename = nameWithoutExtension.replace(/[^a-zA-Z0-9]/g, '-') + extension;
+
+  // Download FIRST and verify it's actually a PDF before doing any S3 work. Many ".pdf"
+  // URLs now 301-redirect to an HTML page (sites migrated off PDFs); axios follows the
+  // redirect and returns HTML, which we'd otherwise upload as a broken "PDF" that the
+  // worker can't open ("cannot open broken document"), burning ~40s/each on retries.
+  console.log(`Fetching candidate PDF. Filename: ${filename}, Url: ${url}`);
+  const response = await axios.get(url, { responseType: 'arraybuffer' });
+  const pdfBuffer = response.data;
+  const contentType = String(response.headers['content-type'] || '').toLowerCase();
+  const head = Buffer.from(pdfBuffer).subarray(0, 5).toString('latin1');
+  if (!contentType.includes('application/pdf') && head !== '%PDF-') {
+    console.warn(`SKIP-PDF (not-a-pdf, content-type=${contentType || 'n/a'}): url=${url}`);
+    return null;
+  }
 
   console.log(`Uploading PDF to S3. Filename: ${filename}, Url: ${url}`);
 
@@ -70,8 +86,19 @@ export async function uploadPdfToS3(url: string, courseName: string) {
 
   const s3Key = `courses/${courseName}/${filename}`;
 
-  const response = await axios.get(url, { responseType: 'arraybuffer' });
-  const pdfBuffer = response.data;
+  // Dedup across crawls: a popular PDF (e.g. a site-wide handbook) is linked from many pages,
+  // so many separate crawl jobs target the SAME s3 key. Without dedup, the duplicate ingest
+  // jobs race the worker's duplicate-handling — which deletes the S3 object to "replace" it —
+  // so the sibling jobs' download 404s ("Error in /ingest: bulk_ingest: HeadObject 404") and
+  // the PDF fails. If the object already exists, an earlier crawl already uploaded + ingested
+  // it, so skip ingest (return null) instead of enqueuing a duplicate job.
+  try {
+    await s3Client.send(new HeadObjectCommand({ Bucket: s3BucketName, Key: s3Key }));
+    console.log(`SKIP-PDF (dup, already in S3): key=${s3Key}, url=${url}`);
+    return null;
+  } catch (headErr) {
+    // NotFound → first crawl to see this PDF; fall through to upload + ingest.
+  }
 
   try {
     await s3Client.send(new PutObjectCommand({


### PR DESCRIPTION
Closes #82

Hardens the crawler so broken/duplicate/error content never enters the ingest pipeline, and fixes the browser launch in the Docker image.

## Changes

**Fix browser launch in the Docker image** (`apps/crawlee/Dockerfile`)
- The base image (`apify/actor-node-playwright-chrome:20`) bundles a chromium matching *its* playwright (1.60), while `package.json` pins playwright `^1.42.1` — so the bundled browser at the root-owned `/pw-browsers` is unusable and every crawl fails with `BrowserLaunchError`. Point `PLAYWRIGHT_BROWSERS_PATH` at a `myuser`-owned dir and install the chromium matching the pinned playwright there (no `--with-deps`; the base image already carries chromium's system libraries).

**PDF guards** (`apps/crawlee/src/api/uploadToS3.ts`)
- Download the candidate PDF *first* and verify it actually is one (`content-type: application/pdf` or `%PDF-` magic bytes) before any S3 work. Many `.pdf` URLs 301-redirect to HTML landing pages, which previously got uploaded as broken "PDFs" the ingest worker can't open (~40s of retries each).
- Dedup uploads with a `HeadObject` check: a popular PDF linked from many crawled pages used to produce one upload+ingest job per page for the same S3 key, and the duplicate jobs race the worker's duplicate-handling (which deletes the object to "replace" it) — sibling jobs then 404 mid-download and the document can be permanently lost. Now only the first crawl to see a PDF uploads and ingests it.
- `uploadPdfToS3` returns `null` for both skip cases; `handlePdf` skips ingest accordingly.

**Error-page filtering** (`apps/crawlee/src/api/crawlee.ts`)
- Before the fire-and-forget ingest POST, `shouldSkipIngest` drops empty pages, hard HTTP 4xx/5xx, soft-404s (HTTP 200 + error `<title>`), and short error-page bodies, so placeholder pages never pollute the corpus.
- Every skip is logged with a greppable `SKIP-INGEST (<reason>)` / `SKIP-PDF (<reason>)` line — the ingest POST is fire-and-forget, so the logs are the only way to monitor what was dropped.

**Cleanup**
- Removed commented-out dead code and the unused `ingestionPromises` plumbing in `crawlee.ts`.

## Verification

- `tsc --noEmit` clean.
- The same guards have been running in production during a ~509k-URL CropWizard re-crawl: `SKIP-PDF (not-a-pdf)` eliminated the broken-document ingest failures, the HeadObject dedup dropped duplicate-PDF failure churn from ~10/min to ~1/min, and soft-404 pages stopped landing in the corpus.
