### PR TITLE
Allow chat API callers to limit retrieved contexts

### DIFF
--- a/apps/backend/docs/api/endpoints.md
+++ b/apps/backend/docs/api/endpoints.md
@@ -100,6 +100,8 @@ print(response.contexts)
 Note: This API response is free of cost provided by UIUC chat and will NOT invoke LLM and ONLY return relevant contexts
 {% endhint %}
 
+Use the optional `top_n` field to limit the response to the highest-ranked contexts. It accepts positive integers and defaults to 100.
+
 ```python
 import requests
 
@@ -122,7 +124,8 @@ data = {
     "openai_key": "YOUR-OPENAI-KEY-HERE",
     "temperature": 0.1,
     "course_name": "your-course-name",
-    "retrieval_only": true
+    "retrieval_only": true,
+    "top_n": 8
 }
 
 response = requests.post(url, headers=headers, json=data)

--- a/apps/frontend/__tests__/pages/api/chat-api/__tests__/chat.test.ts
+++ b/apps/frontend/__tests__/pages/api/chat-api/__tests__/chat.test.ts
@@ -238,12 +238,21 @@ describe('chat-api/chat', () => {
           stream: false,
           api_key: 'k',
           retrieval_only: true,
+          top_n: 8,
         },
         socket: { remoteAddress: '127.0.0.1' } as any,
       }) as any,
       res as any,
     )
     expect(res.status).toHaveBeenCalledWith(200)
+    expect(hoisted.handleContextSearch).toHaveBeenCalledWith(
+      expect.any(Object),
+      'CS101',
+      expect.any(Object),
+      expect.any(String),
+      ['All Documents'],
+      8,
+    )
     expect(hoisted.routeModelRequest).not.toHaveBeenCalled()
   })
 
@@ -360,6 +369,7 @@ describe('chat-api/chat', () => {
       expect.any(Object),
       expect.any(String),
       ['All Documents'],
+      100,
     )
   })
 
@@ -389,6 +399,7 @@ describe('chat-api/chat', () => {
       expect.any(Object),
       expect.any(String),
       ['Group A'],
+      100,
     )
   })
 

--- a/apps/frontend/src/pages/api/chat-api/chat.ts
+++ b/apps/frontend/src/pages/api/chat-api/chat.ts
@@ -94,6 +94,7 @@ export default async function chat(
     retrieval_only,
     conversation_id,
     doc_groups: requestedDocGroups,
+    top_n = 100,
   } = body
 
   // Validate the API key and retrieve user data
@@ -280,6 +281,7 @@ export default async function chat(
     conversation,
     searchQuery,
     doc_groups,
+    top_n,
   )
   // Check if contexts were found
   if (contexts.length === 0) {

--- a/apps/frontend/src/types/chat.ts
+++ b/apps/frontend/src/types/chat.ts
@@ -223,6 +223,7 @@ export interface ChatApiBody {
   retrieval_only?: boolean
   conversation_id?: string
   doc_groups?: string[]
+  top_n?: number
 }
 
 export interface Action {

--- a/apps/frontend/src/utils/__tests__/fetchContexts.test.ts
+++ b/apps/frontend/src/utils/__tests__/fetchContexts.test.ts
@@ -23,7 +23,14 @@ describe('fetchContexts (browser/jsdom)', () => {
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
 
-    await fetchContexts('CS225', 'binary trees', 2000, ['lectures'], 'conv-1')
+    await fetchContexts(
+      'CS225',
+      'binary trees',
+      2000,
+      ['lectures'],
+      'conv-1',
+      8,
+    )
 
     expect(fetchSpy).toHaveBeenCalledTimes(1)
     const [, init] = fetchSpy.mock.calls[0] ?? []
@@ -37,6 +44,7 @@ describe('fetchContexts (browser/jsdom)', () => {
       token_limit: 2000,
       doc_groups: ['lectures'],
       conversation_id: 'conv-1',
+      top_n: 8,
     })
   })
 
@@ -52,6 +60,7 @@ describe('fetchContexts (browser/jsdom)', () => {
     )
     expect(body.token_limit).toBe(4000)
     expect(body.doc_groups).toEqual([])
+    expect(body.top_n).toBe(100)
   })
 
   it('returns [] when /api/getContexts responds not ok', async () => {

--- a/apps/frontend/src/utils/__tests__/fetchContexts.vectorEngine.node.test.ts
+++ b/apps/frontend/src/utils/__tests__/fetchContexts.vectorEngine.node.test.ts
@@ -93,6 +93,10 @@ describe('fetchContextsByVectorEngine / VECTOR_ENGINE routing', () => {
       'https://backend.example/getTopContexts',
       expect.objectContaining({ method: 'POST' }),
     )
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]?.[1] as RequestInit)?.body as string,
+    )
+    expect(body.top_n).toBe(50)
     expect(result).toEqual(data)
   })
 

--- a/apps/frontend/src/utils/__tests__/streamProcessing.test.ts
+++ b/apps/frontend/src/utils/__tests__/streamProcessing.test.ts
@@ -494,6 +494,33 @@ describe('validateRequestBody', () => {
       } as any),
     ).rejects.toThrow(/stream/i)
   })
+
+  it.each([0, -1, 1.5, '8'])(
+    'throws when top_n is invalid: %s',
+    async (top_n) => {
+      await expect(
+        validateRequestBody({
+          model: OpenAIModelID.GPT_4o,
+          messages: [{ id: 'm1', role: 'user', content: 'hi' }],
+          course_name: 'CS101',
+          api_key: 'k',
+          top_n,
+        } as any),
+      ).rejects.toThrow(/top_n/i)
+    },
+  )
+
+  it('allows top_n values greater than the default', async () => {
+    await expect(
+      validateRequestBody({
+        model: OpenAIModelID.GPT_4o,
+        messages: [{ id: 'm1', role: 'user', content: 'hi' }],
+        course_name: 'CS101',
+        api_key: 'k',
+        top_n: 101,
+      }),
+    ).resolves.toBeUndefined()
+  })
 })
 
 describe('constructSearchQuery', () => {
@@ -544,8 +571,9 @@ describe('handleContextSearch / attachContextsToLastMessage', () => {
       selectedConversation,
       'q',
       ['g1'],
+      8,
     )
-    expect(fetchContexts).toHaveBeenCalledWith('CS101', 'q', 123, ['g1'], '')
+    expect(fetchContexts).toHaveBeenCalledWith('CS101', 'q', 123, ['g1'], '', 8)
     expect(contexts).toEqual([{ id: 2 }])
     expect(message.contexts).toEqual([{ id: 2 }])
   })

--- a/apps/frontend/src/utils/fetchContexts.ts
+++ b/apps/frontend/src/utils/fetchContexts.ts
@@ -13,6 +13,7 @@ export default async function fetchContextsFromBackend(
   token_limit = 4000,
   doc_groups: string[] = [],
   conversation_id?: string,
+  top_n = 100,
   signal?: AbortSignal,
 ): Promise<ContextWithMetadata[]> {
   const backendUrl = getBackendUrl()
@@ -23,6 +24,7 @@ export default async function fetchContextsFromBackend(
     token_limit: token_limit,
     doc_groups: doc_groups,
     conversation_id: conversation_id,
+    top_n: top_n,
   }
 
   const response = await fetch(`${backendUrl}/getTopContexts`, {
@@ -65,6 +67,7 @@ export async function fetchContextsByVectorEngine(
       token_limit,
       doc_groups,
       conversation_id,
+      top_n,
       signal,
     )
   }
@@ -88,6 +91,7 @@ export const fetchContexts = async (
   token_limit = 4000,
   doc_groups: string[] = [],
   conversation_id?: string,
+  top_n = 100,
 ): Promise<ContextWithMetadata[]> => {
   // Check if we're running on client-side (browser) or server-side
   const isClientSide = typeof window !== 'undefined'
@@ -108,6 +112,7 @@ export const fetchContexts = async (
             token_limit,
             doc_groups,
             conversation_id,
+            top_n,
           }),
         },
       )
@@ -127,6 +132,7 @@ export const fetchContexts = async (
         token_limit,
         doc_groups,
         conversation_id,
+        top_n,
       )
     }
   } catch (error) {

--- a/apps/frontend/src/utils/streamProcessing.ts
+++ b/apps/frontend/src/utils/streamProcessing.ts
@@ -391,6 +391,15 @@ export async function validateRequestBody(body: ChatApiBody): Promise<void> {
     throw new Error("Invalid stream provided. 'stream' must be a boolean.")
   }
 
+  if (
+    body.top_n !== undefined &&
+    (!Number.isInteger(body.top_n) || body.top_n < 1)
+  ) {
+    throw new Error(
+      "Invalid top_n provided. 'top_n' must be a positive integer.",
+    )
+  }
+
   const hasImageContent = body.messages.some(
     (message) =>
       Array.isArray(message.content) &&
@@ -433,6 +442,7 @@ export const handleContextSearch = async (
   selectedConversation: Conversation,
   searchQuery: string,
   documentGroups: string[],
+  topN = 100,
 ): Promise<ContextWithMetadata[]> => {
   // Check if this message already has contexts (from file upload)
   if (
@@ -446,14 +456,22 @@ export const handleContextSearch = async (
     const token_limit = selectedConversation.model.tokenLimit
     const useMQRetrieval = false
 
-    const fetchContextsFunc = useMQRetrieval ? fetchMQRContexts : fetchContexts
-    const curr_contexts = await fetchContextsFunc(
-      courseName,
-      searchQuery,
-      token_limit,
-      documentGroups,
-      '',
-    )
+    const curr_contexts = useMQRetrieval
+      ? await fetchMQRContexts(
+          courseName,
+          searchQuery,
+          token_limit,
+          documentGroups,
+          '',
+        )
+      : await fetchContexts(
+          courseName,
+          searchQuery,
+          token_limit,
+          documentGroups,
+          '',
+          topN,
+        )
 
     message.contexts = curr_contexts as ContextWithMetadata[]
     return curr_contexts as ContextWithMetadata[]


### PR DESCRIPTION
## Summary
- add an optional `top_n` field to `/api/chat-api/chat`
- keep the existing default of 100 contexts when the field is omitted
- validate explicit limits as positive integers without imposing an upper bound
- propagate the limit through both pgvector and Qdrant retrieval paths
- document the request field and cover default/override behavior

## Why
Retrieval-only API consumers may need only a small ranked context set. Letting them request, for example, `"top_n": 10` reduces response size and downstream processing without changing behavior for existing callers.

## Validation
- `npx vitest run __tests__/pages/api/chat-api/__tests__/chat.test.ts src/utils/__tests__/streamProcessing.test.ts src/utils/__tests__/fetchContexts.test.ts src/utils/__tests__/fetchContexts.vectorEngine.node.test.ts --pool=threads --maxWorkers=1 --minWorkers=1` (94 tests passed)
- focused ESLint on all changed TypeScript files (0 errors)
- `git diff --check`

## Typecheck note
The repository-wide `npx tsc --noEmit` remains blocked by existing test typing errors across the current `main` branch. None of the reported errors reference the production files changed here.