### PR TITLE
ci: set pr-checks trunk check-mode to none to match push-to-main

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,10 +16,26 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Matches illinois-chat-dev.yml (push to main), which also uses
+      # check-mode: none. Trunk is installed but runs no checks.
+      #
+      # Why: main has never been linted -- the only workflow that runs on
+      # pushes to main sets check-mode: none -- so violations accumulated
+      # freely. check-mode: all here pointed trunk at the whole accumulated
+      # tree (1436 files, 895 issues) and attributed every pre-existing issue
+      # to whichever PR happened to be open, so every PR failed regardless of
+      # its contents.
+      #
+      # This is a stopgap that unblocks PRs by making both workflows agree.
+      # It does mean no lint coverage anywhere. See #86 for the real fix
+      # (check-mode: pull_request so PRs lint only their own diff, plus a
+      # .trunk/trunk.yaml exclusion for apps/frontend, whose prettier.config.cjs
+      # requires prettier-plugin-tailwindcss that trunk's hermetic prettier
+      # cannot resolve).
       - name: Install Trunk
         uses: trunk-io/trunk-action@v1
         with:
-          check-mode: all
+          check-mode: none
 
       # Backend tests placeholder
       - name: Backend tests


### PR DESCRIPTION
## Problem

`pr-checks.yml` runs trunk with `check-mode: all`, while `illinois-chat-dev.yml` — the only workflow that runs on pushes to `main` — runs it with `check-mode: none`.

Because of that asymmetry, **`main` has never been linted.** Violations accumulated freely, and `check-mode: all` then pointed trunk at the entire accumulated tree on every PR:

```
Checked 1436 files
✖ 895 issues (144 auto-fixable)
```

Every pre-existing issue in the repo gets attributed to whichever PR happens to be open, so PRs fail regardless of their contents. `PR Checks` has **never** run with head branch `main` — there is no baseline it has ever been green against.

The bulk of the 895 issues trace to one toolchain problem, not real formatting:

```
[error] Cannot find module 'prettier-plugin-tailwindcss'
[error] - apps/frontend/prettier.config.cjs
prettier exited with exit_code=2
```

Trunk runs its own hermetic prettier under `env -i` with `NODE_PATH` pointed at trunk's sandbox, so it cannot load `apps/frontend/prettier.config.cjs`, and exits 2 on every file that config covers.

## Scope of the breakage

Every `PR Checks` run since 2026-07-03 has failed — 50 failures across every branch in the repo (`feat/countries-of-concern`, `fix/folder-filter-by-project`, `simai`, `88-external-connection-manager`, `84-create-chatbot-wizard-...`, and others). The single exception is the #86 fix branch on 2026-07-21, still unmerged.

## This change

One functional line: `check-mode: all` → `check-mode: none`, matching `illinois-chat-dev.yml`. Both workflows now agree, and PRs stop failing on issues they didn't introduce.

## Tradeoff — please read before merging

**This removes lint coverage on PRs.** It does not fix anything; it makes the PR side as unchecked as `main` already is. It is a stopgap to unblock the queue.

The real fix is #86: `check-mode: pull_request` so PRs lint only their own diff, plus a `.trunk/trunk.yaml` exclusion for `apps/frontend/**` so trunk's prettier stops failing on a config it cannot load. If #86 is close to landing, merge that instead of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)