### PR TITLE
Gate dashboard ingest polling and filter the document status endpoints

### DIFF
--- a/apps/frontend/__tests__/pages/api/materialsTable/__tests__/materialsTable.test.ts
+++ b/apps/frontend/__tests__/pages/api/materialsTable/__tests__/materialsTable.test.ts
@@ -9,6 +9,7 @@ const hoisted = vi.hoisted(() => {
     select,
     posthogCapture: vi.fn(),
     getDocumentsDb: vi.fn(async () => ({ select })),
+    inArray: vi.fn(() => ({})),
   }
 })
 
@@ -68,7 +69,7 @@ vi.mock('drizzle-orm', () => {
     eq: () => ({}),
     and: () => ({}),
     or: () => ({}),
-    inArray: () => ({}),
+    inArray: hoisted.inArray,
     gte: () => ({}),
     asc: () => ({}),
     desc: () => ({}),
@@ -86,6 +87,39 @@ describe('materialsTable API handlers', () => {
   beforeEach(() => {
     hoisted.select.mockReset()
     hoisted.posthogCapture.mockReset()
+    hoisted.inArray.mockClear()
+  })
+
+  // The whole point of issue #90: these routes must never read the table
+  // without narrowing it to what the caller is tracking.
+  it.each([
+    ['docsInProgress', () => docsInProgressHandler],
+    ['successDocs', () => successDocsHandler],
+  ])('%s narrows the query to the requested filters', async (_name, get) => {
+    hoisted.select.mockImplementationOnce(() => ({
+      from: () => ({ where: vi.fn().mockResolvedValueOnce([]) }),
+    }))
+
+    const res = createMockRes()
+    await get()(
+      createMockReq({
+        method: 'POST',
+        body: {
+          course_name: 'CS101',
+          filenames: ['a.pdf', 'b.pdf'],
+          base_urls: ['https://a.com/'],
+        },
+      }) as any,
+      res as any,
+    )
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    const filterValues = hoisted.inArray.mock.calls.map(
+      (call: any[]) => call[1],
+    )
+    expect(filterValues).toContainEqual(['a.pdf', 'b.pdf'])
+    // Normalized, so it matches rows stored without the trailing slash.
+    expect(filterValues).toContainEqual(['https://a.com'])
   })
 
   it('docsInProgress returns 405 for non-POST', async () => {

--- a/apps/frontend/__tests__/pages/api/materialsTable/__tests__/materialsTable.test.ts
+++ b/apps/frontend/__tests__/pages/api/materialsTable/__tests__/materialsTable.test.ts
@@ -88,6 +88,32 @@ describe('materialsTable API handlers', () => {
     hoisted.select.mockReset()
     hoisted.posthogCapture.mockReset()
     hoisted.inArray.mockClear()
+    hoisted.getDocumentsDb.mockClear()
+  })
+
+  // The auth wrapper resolves the course from query params, body or headers,
+  // so the body's course_name is not necessarily the one it authorized.
+  it.each([
+    ['docsInProgress', () => docsInProgressHandler],
+    ['successDocs', () => successDocsHandler],
+  ])('%s reads the authorized course, not the body', async (_name, get) => {
+    hoisted.select.mockImplementationOnce(() => ({
+      from: () => ({ where: vi.fn().mockResolvedValueOnce([]) }),
+    }))
+
+    const res = createMockRes()
+    await get()(
+      createMockReq({
+        method: 'POST',
+        courseName: 'authorized-project',
+        body: { course_name: 'other-project', filenames: ['a.pdf'] },
+      }) as any,
+      res as any,
+    )
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(hoisted.getDocumentsDb).toHaveBeenCalledWith('authorized-project')
+    expect(hoisted.getDocumentsDb).not.toHaveBeenCalledWith('other-project')
   })
 
   // The whole point of issue #90: these routes must never read the table

--- a/apps/frontend/__tests__/pages/api/materialsTable/__tests__/materialsTable.test.ts
+++ b/apps/frontend/__tests__/pages/api/materialsTable/__tests__/materialsTable.test.ts
@@ -146,6 +146,30 @@ describe('materialsTable API handlers', () => {
     })
   })
 
+  it('docsInProgress drops unusable filter entries instead of failing', async () => {
+    hoisted.select.mockImplementationOnce(() => ({
+      from: () => ({
+        where: vi.fn().mockResolvedValueOnce([]),
+      }),
+    }))
+
+    const res = createMockRes()
+    await docsInProgressHandler(
+      createMockReq({
+        method: 'POST',
+        // '' and '/' can't match anything; 'Doc A' still can, so the request
+        // must succeed rather than 400 and freeze the caller's statuses.
+        body: {
+          course_name: 'CS101',
+          filenames: ['', 'Doc A'],
+          base_urls: ['/'],
+        },
+      }) as any,
+      res as any,
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
   it('docsInProgress accepts base_urls filters (normalized)', async () => {
     hoisted.select.mockImplementationOnce(() => ({
       from: () => ({
@@ -182,15 +206,12 @@ describe('materialsTable API handlers', () => {
   it.each([
     ['missing course_name', { filenames: ['a.pdf'] }],
     ['missing filters', { course_name: 'CS101' }],
-    ['empty filter arrays', { course_name: 'CS101', filenames: [], base_urls: [] }],
     [
-      'malformed filenames',
-      { course_name: 'CS101', filenames: ['ok', 42] },
+      'empty filter arrays',
+      { course_name: 'CS101', filenames: [], base_urls: [] },
     ],
-    [
-      'malformed base_urls',
-      { course_name: 'CS101', base_urls: [null] },
-    ],
+    ['malformed filenames', { course_name: 'CS101', filenames: ['ok', 42] }],
+    ['malformed base_urls', { course_name: 'CS101', base_urls: [null] }],
     [
       'over the item cap',
       {
@@ -203,7 +224,10 @@ describe('materialsTable API handlers', () => {
     async (_label, body) => {
       for (const handler of [docsInProgressHandler, successDocsHandler]) {
         const res = createMockRes()
-        await handler(createMockReq({ method: 'POST', body }) as any, res as any)
+        await handler(
+          createMockReq({ method: 'POST', body }) as any,
+          res as any,
+        )
         expect(res.status).toHaveBeenCalledWith(400)
       }
     },

--- a/apps/frontend/__tests__/pages/api/materialsTable/__tests__/materialsTable.test.ts
+++ b/apps/frontend/__tests__/pages/api/materialsTable/__tests__/materialsTable.test.ts
@@ -67,6 +67,8 @@ vi.mock('drizzle-orm', () => {
     relations: () => ({}),
     eq: () => ({}),
     and: () => ({}),
+    or: () => ({}),
+    inArray: () => ({}),
     gte: () => ({}),
     asc: () => ({}),
     desc: () => ({}),
@@ -86,10 +88,13 @@ describe('materialsTable API handlers', () => {
     hoisted.posthogCapture.mockReset()
   })
 
-  it('docsInProgress returns 405 for non-GET', async () => {
+  it('docsInProgress returns 405 for non-POST', async () => {
     const res = createMockRes()
     await docsInProgressHandler(
-      createMockReq({ method: 'POST' }) as any,
+      createMockReq({
+        method: 'GET',
+        query: { course_name: 'CS101' },
+      }) as any,
       res as any,
     )
     expect(res.status).toHaveBeenCalledWith(405)
@@ -104,7 +109,10 @@ describe('materialsTable API handlers', () => {
 
     const res1 = createMockRes()
     await docsInProgressHandler(
-      createMockReq({ method: 'GET', query: { course_name: 'CS101' } }) as any,
+      createMockReq({
+        method: 'POST',
+        body: { course_name: 'CS101', filenames: ['Doc A'] },
+      }) as any,
       res1 as any,
     )
     expect(res1.status).toHaveBeenCalledWith(200)
@@ -123,7 +131,10 @@ describe('materialsTable API handlers', () => {
 
     const res2 = createMockRes()
     await docsInProgressHandler(
-      createMockReq({ method: 'GET', query: { course_name: 'CS101' } }) as any,
+      createMockReq({
+        method: 'POST',
+        body: { course_name: 'CS101', filenames: ['Doc A'] },
+      }) as any,
       res2 as any,
     )
     expect(res2.status).toHaveBeenCalledWith(200)
@@ -134,6 +145,69 @@ describe('materialsTable API handlers', () => {
       ],
     })
   })
+
+  it('docsInProgress accepts base_urls filters (normalized)', async () => {
+    hoisted.select.mockImplementationOnce(() => ({
+      from: () => ({
+        where: vi.fn().mockResolvedValueOnce([
+          {
+            readable_filename: 'page',
+            base_url: 'https://a.com',
+            url: 'https://a.com/x',
+          },
+        ]),
+      }),
+    }))
+
+    const res = createMockRes()
+    await docsInProgressHandler(
+      createMockReq({
+        method: 'POST',
+        body: { course_name: 'CS101', base_urls: ['https://a.com/'] },
+      }) as any,
+      res as any,
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({
+      documents: [
+        {
+          readable_filename: 'page',
+          base_url: 'https://a.com',
+          url: 'https://a.com/x',
+        },
+      ],
+    })
+  })
+
+  it.each([
+    ['missing course_name', { filenames: ['a.pdf'] }],
+    ['missing filters', { course_name: 'CS101' }],
+    ['empty filter arrays', { course_name: 'CS101', filenames: [], base_urls: [] }],
+    [
+      'malformed filenames',
+      { course_name: 'CS101', filenames: ['ok', 42] },
+    ],
+    [
+      'malformed base_urls',
+      { course_name: 'CS101', base_urls: [null] },
+    ],
+    [
+      'over the item cap',
+      {
+        course_name: 'CS101',
+        filenames: Array.from({ length: 1001 }, (_, i) => `f${i}.pdf`),
+      },
+    ],
+  ])(
+    'docsInProgress and successDocs return 400 for %s',
+    async (_label, body) => {
+      for (const handler of [docsInProgressHandler, successDocsHandler]) {
+        const res = createMockRes()
+        await handler(createMockReq({ method: 'POST', body }) as any, res as any)
+        expect(res.status).toHaveBeenCalledWith(400)
+      }
+    },
+  )
 
   it('fetchIfDocumentExists validates method and course_name', async () => {
     const badMethodRes = createMockRes()
@@ -220,13 +294,20 @@ describe('materialsTable API handlers', () => {
     expect(res.json).toHaveBeenCalledWith({ error: 'db down' })
   })
 
-  it('successDocs returns mapped documents (or empty) and 405 for non-GET', async () => {
+  it('successDocs returns mapped documents (or empty) and 405 for non-POST', async () => {
     const res0 = createMockRes()
     await successDocsHandler(
       createMockReq({ method: 'PUT' }) as any,
       res0 as any,
     )
     expect(res0.status).toHaveBeenCalledWith(405)
+
+    const resGet = createMockRes()
+    await successDocsHandler(
+      createMockReq({ method: 'GET', query: { course_name: 'CS101' } }) as any,
+      resGet as any,
+    )
+    expect(resGet.status).toHaveBeenCalledWith(405)
 
     hoisted.select.mockImplementationOnce(() => ({
       from: () => ({
@@ -236,7 +317,10 @@ describe('materialsTable API handlers', () => {
 
     const res1 = createMockRes()
     await successDocsHandler(
-      createMockReq({ method: 'GET', query: { course_name: 'CS101' } }) as any,
+      createMockReq({
+        method: 'POST',
+        body: { course_name: 'CS101', filenames: ['Doc'] },
+      }) as any,
       res1 as any,
     )
     expect(res1.status).toHaveBeenCalledWith(200)
@@ -253,7 +337,14 @@ describe('materialsTable API handlers', () => {
 
     const res2 = createMockRes()
     await successDocsHandler(
-      createMockReq({ method: 'GET', query: { course_name: 'CS101' } }) as any,
+      createMockReq({
+        method: 'POST',
+        body: {
+          course_name: 'CS101',
+          filenames: ['Doc'],
+          base_urls: ['b'],
+        },
+      }) as any,
       res2 as any,
     )
     expect(res2.status).toHaveBeenCalledWith(200)

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -162,7 +162,6 @@
         "@types/prettier": "^2.7.2",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
-        "@types/react-query": "^1.2.9",
         "@types/react-syntax-highlighter": "^15.5.6",
         "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
@@ -11352,16 +11351,6 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@types/react-query": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@types/react-query/-/react-query-1.2.9.tgz",
-      "integrity": "sha512-xfVcv5zjC6fGf6axPyKxdXNm9RKK9OFzSIyZeCR3r9h4zDuqSpHc8ilTBtfQ1zU/uCx+tAsB+W6vzdCBMu1jtg==",
-      "deprecated": "This is a stub types definition. react-query provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "react-query": "*"
-      }
-    },
     "node_modules/@types/react-syntax-highlighter": {
       "version": "15.5.13",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
@@ -13785,15 +13774,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -13883,22 +13863,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "node_modules/browser-stdout": {
@@ -15546,12 +15510,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -19934,12 +19892,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "dev": true
-    },
     "node_modules/js-tiktoken": {
       "version": "1.0.21",
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
@@ -21259,16 +21211,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/match-sorter": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.4.tgz",
-      "integrity": "sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.23.8",
-        "remove-accents": "0.5.0"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -22105,12 +22047,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==",
-      "dev": true
-    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -22551,15 +22487,6 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
-      }
-    },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "dev": true,
-      "dependencies": {
-        "big-integer": "^1.6.16"
       }
     },
     "node_modules/nanoid": {
@@ -23395,12 +23322,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
       "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg=="
-    },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==",
-      "dev": true
     },
     "node_modules/oidc-client-ts": {
       "version": "3.4.1",
@@ -25207,32 +25128,6 @@
         "react": ">=16.14.0"
       }
     },
-    "node_modules/react-query": {
-      "version": "3.39.3",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
-      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -25799,12 +25694,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -28760,16 +28649,6 @@
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
       }
     },
     "node_modules/unrs-resolver": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -184,7 +184,6 @@
     "@types/prettier": "^2.7.2",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "@types/react-query": "^1.2.9",
     "@types/react-syntax-highlighter": "^15.5.6",
     "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.56.0",

--- a/apps/frontend/src/components/UIUC-Components/CanvasIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/CanvasIngestForm.tsx
@@ -113,6 +113,10 @@ export default function CanvasIngestForm({
         })
 
         await new Promise((resolve) => setTimeout(resolve, 8000)) // wait a moment before redirecting
+        // Ingestion is queued, so rows usually land after the request returns.
+        queryClient.invalidateQueries({
+          queryKey: ['documents', project_name],
+        })
         console.log('Canvas content ingestion was successful!')
         console.log('Ingesting:', url, 'with options:', selectedOptions)
       } catch (error) {

--- a/apps/frontend/src/components/UIUC-Components/CanvasIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/CanvasIngestForm.tsx
@@ -125,6 +125,9 @@ export default function CanvasIngestForm({
             file.name === url ? { ...file, status: 'error' } : file,
           ),
         )
+        void queryClient.invalidateQueries({
+          queryKey: ['failedDocuments', project_name],
+        })
         console.error('Error ingesting Canvas content:', error)
         alert('Error ingesting Canvas content. Please try again.')
       }

--- a/apps/frontend/src/components/UIUC-Components/CanvasIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/CanvasIngestForm.tsx
@@ -113,10 +113,6 @@ export default function CanvasIngestForm({
         })
 
         await new Promise((resolve) => setTimeout(resolve, 8000)) // wait a moment before redirecting
-        // Ingestion is queued, so rows usually land after the request returns.
-        queryClient.invalidateQueries({
-          queryKey: ['documents', project_name],
-        })
         console.log('Canvas content ingestion was successful!')
         console.log('Ingesting:', url, 'with options:', selectedOptions)
       } catch (error) {

--- a/apps/frontend/src/components/UIUC-Components/GitHubIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/GitHubIngestForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Text, Card, Button, Input, createStyles } from '@mantine/core'
 import {
   IconAlertCircle,
@@ -23,16 +23,19 @@ import { Montserrat } from 'next/font/google'
 import { type FileUpload } from './UploadNotification'
 import Link from 'next/link'
 import { type QueryClient } from '@tanstack/react-query'
+import { fetchIngestStatus } from '~/utils/ingestStatusClient'
 const montserrat_med = Montserrat({
   weight: '500',
   subsets: ['latin'],
 })
 export default function GitHubIngestForm({
   project_name,
+  uploadFiles,
   setUploadFiles,
   queryClient,
 }: {
   project_name: string
+  uploadFiles: FileUpload[]
   setUploadFiles: React.Dispatch<React.SetStateAction<FileUpload[]>>
   queryClient: QueryClient
 }): JSX.Element {
@@ -115,7 +118,6 @@ export default function GitHubIngestForm({
       },
     },
   }))
-  const [isUrlUpdated, setIsUrlUpdated] = useState(false)
   const [isUrlValid, setIsUrlValid] = useState(false)
   const [url, setUrl] = useState('')
   const [maxUrls, setMaxUrls] = useState('50')
@@ -182,25 +184,79 @@ export default function GitHubIngestForm({
     await new Promise((resolve) => setTimeout(resolve, 8000))
   }
 
+  // Poll ingest status only while GitHub ingests are tracked and active. The
+  // tracked repo URLs are sent as a server-side filter so the endpoints never
+  // return the whole documents table.
+  const isPollingActive = uploadFiles.some(
+    (file) =>
+      file.type === 'github' &&
+      (file.status === 'uploading' || file.status === 'ingesting'),
+  )
+  const uploadFilesRef = useRef(uploadFiles)
+  uploadFilesRef.current = uploadFiles
+  const wasPollingActiveRef = useRef(false)
+
   useEffect(() => {
-    if (url && url.length > 0 && validateUrl(url)) {
-      setIsUrlUpdated(true)
-    } else {
-      setIsUrlUpdated(false)
+    if (!isPollingActive) {
+      if (wasPollingActiveRef.current) {
+        // Gate just closed — final refresh as a backstop for any invalidation
+        // missed by per-tick diffs.
+        wasPollingActiveRef.current = false
+        void queryClient.invalidateQueries({
+          queryKey: ['documents', project_name],
+        })
+        void queryClient.invalidateQueries({
+          queryKey: ['failedDocuments', project_name],
+        })
+      }
+      return
     }
-  }, [url])
+    wasPollingActiveRef.current = true
+    let inFlight = false
 
-  useEffect(() => {
     const checkIngestStatus = async () => {
-      const response = await fetch(
-        `/api/materialsTable/docsInProgress?course_name=${project_name}`,
-      )
-      const data = await response.json()
-      const docsResponse = await fetch(
-        `/api/materialsTable/successDocs?course_name=${project_name}`,
-      )
-      const docsData = await docsResponse.json()
+      if (inFlight) return
+      inFlight = true
+      try {
+        // Filter on the repo URLs of ALL tracked base entries regardless of
+        // their status (base entries are the ones without a `url` field):
+        // child rows carry the base's base_url, so this returns every row the
+        // matching below needs — including children that are still resolving
+        // after the base entry itself went terminal.
+        const trackedBaseUrls = uploadFilesRef.current
+          .filter((file) => file.type === 'github' && !file.url)
+          .map((file) => file.name)
+          .filter((baseUrl) => baseUrl.length > 0)
 
+        const status = await fetchIngestStatus(project_name, {
+          base_urls: trackedBaseUrls,
+        })
+        // A failed request must not be read as "doc vanished" — skip the tick.
+        if (!status) return
+
+        const data = { documents: status.inProgress }
+        const docsData = { documents: status.completed }
+
+        applyIngestStatus(data, docsData)
+      } catch (error) {
+        console.error('Error checking ingest status:', error)
+      } finally {
+        inFlight = false
+      }
+    }
+
+    const interval = setInterval(checkIngestStatus, 3000)
+    return () => {
+      clearInterval(interval)
+    }
+  }, [isPollingActive, project_name])
+
+  const applyIngestStatus = (
+    data: {
+      documents: Array<{ base_url: string; url: string; readable_filename: string }>
+    },
+    docsData: { documents: Array<{ base_url: string; url: string }> },
+  ) => {
       // Helper function to organize docs by base URL
       const organizeDocsByBaseUrl = (
         docs: Array<{ base_url: string; url: string }>,
@@ -285,35 +341,52 @@ export default function GitHubIngestForm({
         return newFiles
       }
 
-      setUploadFiles((prev) => {
+      const computeNextFiles = (currentFiles: FileUpload[]) => {
         const matchingDocsInProgress =
           data?.documents?.filter((doc: { base_url: string }) =>
-            prev.some((file) => file.name === doc.base_url),
+            currentFiles.some((file) => file.name === doc.base_url),
           ) || []
 
         const baseUrlMap = organizeDocsByBaseUrl(matchingDocsInProgress)
 
         const additionalFiles = createAdditionalFileEntries(
           baseUrlMap,
-          prev,
+          currentFiles,
           matchingDocsInProgress,
         )
 
-        const updatedFiles = updateExistingFiles(prev, matchingDocsInProgress)
+        const updatedFiles = updateExistingFiles(
+          currentFiles,
+          matchingDocsInProgress,
+        )
 
         return [...updatedFiles, ...additionalFiles]
-      })
+      }
 
-      await queryClient.invalidateQueries({
-        queryKey: ['documents', project_name],
-      })
-    }
+      // Diff against a snapshot so the table is only refreshed when this tick
+      // actually changed something (statuses or new entries).
+      const snapshot = uploadFilesRef.current
+      const nextFiles = computeNextFiles(snapshot)
+      const changed =
+        nextFiles.length !== snapshot.length ||
+        nextFiles.some((file, i) => file !== snapshot[i])
+      const hasErrorTransition = nextFiles.some(
+        (file, i) => file !== snapshot[i] && file.status === 'error',
+      )
 
-    const interval = setInterval(checkIngestStatus, 3000)
-    return () => {
-      clearInterval(interval)
-    }
-  }, [project_name])
+      setUploadFiles((prev) => computeNextFiles(prev))
+
+      if (changed) {
+        void queryClient.invalidateQueries({
+          queryKey: ['documents', project_name],
+        })
+      }
+      if (hasErrorTransition) {
+        void queryClient.invalidateQueries({
+          queryKey: ['failedDocuments', project_name],
+        })
+      }
+  }
 
   // if (isLoading) {
   //   return <Skeleton height={200} width={330} radius={'lg'} />

--- a/apps/frontend/src/components/UIUC-Components/GitHubIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/GitHubIngestForm.tsx
@@ -455,7 +455,6 @@ export default function GitHubIngestForm({
           if (!isOpen) {
             setUrl('')
             setIsUrlValid(false)
-            setIsUrlUpdated(false)
             setMaxUrls('50')
           }
         }}

--- a/apps/frontend/src/components/UIUC-Components/GitHubIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/GitHubIngestForm.tsx
@@ -255,27 +255,20 @@ export default function GitHubIngestForm({
         })
       }
 
-      // Helper function to create new file entries for additional URLs
+      // Helper function to create new file entries for additional URLs.
+      // Every key of baseUrlMap comes from an in-progress doc, so anything it
+      // yields is by definition still ingesting.
       const createAdditionalFileEntries = (
         baseUrlMap: Map<string, Set<string>>,
         currentFiles: FileUpload[],
-        docsInProgress: Array<{ base_url: string; readable_filename: string }>,
       ) => {
         const newFiles: FileUpload[] = []
 
         baseUrlMap.forEach((urls, baseUrl) => {
           // Only process if we have this base URL in our current files
           if (currentFiles.some((file) => file.name === baseUrl)) {
-            const matchingDoc = docsInProgress.find(
-              (doc) => doc.base_url === baseUrl,
-            )
-
             urls.forEach((url) => {
-              if (
-                !currentFiles.some((file) => file.url === url) &&
-                matchingDoc
-              ) {
-                // Only reached when the base URL is still in progress.
+              if (!currentFiles.some((file) => file.url === url)) {
                 newFiles.push({
                   name: url,
                   status: 'ingesting',
@@ -297,7 +290,6 @@ export default function GitHubIngestForm({
       const additionalFiles = createAdditionalFileEntries(
         organizeDocsByBaseUrl(matchingDocsInProgress),
         currentFiles,
-        matchingDocsInProgress,
       )
 
       const updatedFiles = updateExistingFiles(

--- a/apps/frontend/src/components/UIUC-Components/GitHubIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/GitHubIngestForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useState } from 'react'
 import { Text, Card, Button, Input, createStyles } from '@mantine/core'
 import {
   IconAlertCircle,
@@ -23,11 +23,13 @@ import { Montserrat } from 'next/font/google'
 import { type FileUpload } from './UploadNotification'
 import Link from 'next/link'
 import { type QueryClient } from '@tanstack/react-query'
-import { fetchIngestStatus } from '~/utils/ingestStatusClient'
+import { useGatedIngestPoller } from '~/hooks/useGatedIngestPoller'
 const montserrat_med = Montserrat({
   weight: '500',
   subsets: ['latin'],
 })
+
+const POLL_INTERVAL_MS = 3000
 export default function GitHubIngestForm({
   project_name,
   uploadFiles,
@@ -161,7 +163,7 @@ export default function GitHubIngestForm({
       }
       setUploadFiles((prevFiles) => [...prevFiles, newFile])
       try {
-        const response = await scrapeWeb(
+        await scrapeWeb(
           url,
           project_name,
           maxUrls.trim() !== '' ? parseInt(maxUrls) : 50,
@@ -184,79 +186,27 @@ export default function GitHubIngestForm({
     await new Promise((resolve) => setTimeout(resolve, 8000))
   }
 
-  // Poll ingest status only while GitHub ingests are tracked and active. The
-  // tracked repo URLs are sent as a server-side filter so the endpoints never
-  // return the whole documents table.
-  const isPollingActive = uploadFiles.some(
-    (file) =>
-      file.type === 'github' &&
-      (file.status === 'uploading' || file.status === 'ingesting'),
-  )
-  const uploadFilesRef = useRef(uploadFiles)
-  uploadFilesRef.current = uploadFiles
-  const wasPollingActiveRef = useRef(false)
-
-  useEffect(() => {
-    if (!isPollingActive) {
-      if (wasPollingActiveRef.current) {
-        // Gate just closed — final refresh as a backstop for any invalidation
-        // missed by per-tick diffs.
-        wasPollingActiveRef.current = false
-        void queryClient.invalidateQueries({
-          queryKey: ['documents', project_name],
-        })
-        void queryClient.invalidateQueries({
-          queryKey: ['failedDocuments', project_name],
-        })
-      }
-      return
-    }
-    wasPollingActiveRef.current = true
-    let inFlight = false
-
-    const checkIngestStatus = async () => {
-      if (inFlight) return
-      inFlight = true
-      try {
-        // Filter on the repo URLs of ALL tracked base entries regardless of
-        // their status (base entries are the ones without a `url` field):
-        // child rows carry the base's base_url, so this returns every row the
-        // matching below needs — including children that are still resolving
-        // after the base entry itself went terminal.
-        const trackedBaseUrls = uploadFilesRef.current
-          .filter((file) => file.type === 'github' && !file.url)
-          .map((file) => file.name)
-          .filter((baseUrl) => baseUrl.length > 0)
-
-        const status = await fetchIngestStatus(project_name, {
-          base_urls: trackedBaseUrls,
-        })
-        // A failed request must not be read as "doc vanished" — skip the tick.
-        if (!status) return
-
-        const data = { documents: status.inProgress }
-        const docsData = { documents: status.completed }
-
-        applyIngestStatus(data, docsData)
-      } catch (error) {
-        console.error('Error checking ingest status:', error)
-      } finally {
-        inFlight = false
-      }
-    }
-
-    const interval = setInterval(checkIngestStatus, 3000)
-    return () => {
-      clearInterval(interval)
-    }
-  }, [isPollingActive, project_name])
-
-  const applyIngestStatus = (
-    data: {
-      documents: Array<{ base_url: string; url: string; readable_filename: string }>
-    },
-    docsData: { documents: Array<{ base_url: string; url: string }> },
-  ) => {
+  // Poll ingest status only while GitHub ingests are in flight, sending the
+  // tracked repo URLs as a server-side filter so the endpoints never return
+  // the whole documents table.
+  useGatedIngestPoller({
+    courseName: project_name,
+    uploadFiles,
+    setUploadFiles,
+    queryClient,
+    type: 'github',
+    intervalMs: POLL_INTERVAL_MS,
+    // Filter on the repo URLs of ALL tracked base entries regardless of their
+    // status (base entries are the ones without a `url` field): child rows
+    // carry the base's base_url, so this returns every row the matching below
+    // needs — including children still resolving after the base went terminal.
+    buildFilter: (files) => ({
+      base_urls: files
+        .filter((file) => file.type === 'github' && !file.url)
+        .map((file) => file.name)
+        .filter((baseUrl) => baseUrl.length > 0),
+    }),
+    applyStatus: (status, currentFiles) => {
       // Helper function to organize docs by base URL
       const organizeDocsByBaseUrl = (
         docs: Array<{ base_url: string; url: string }>,
@@ -289,8 +239,8 @@ export default function GitHubIngestForm({
             return { ...file, status: 'ingesting' as const }
           } else if (file.status === 'ingesting') {
             if (!isStillIngesting) {
-              const isInCompletedDocs = docsData?.documents?.some(
-                (doc: { url: string }) => doc.url === file.url,
+              const isInCompletedDocs = status.completed.some(
+                (doc) => doc.url === file.url,
               )
 
               if (isInCompletedDocs) {
@@ -341,52 +291,24 @@ export default function GitHubIngestForm({
         return newFiles
       }
 
-      const computeNextFiles = (currentFiles: FileUpload[]) => {
-        const matchingDocsInProgress =
-          data?.documents?.filter((doc: { base_url: string }) =>
-            currentFiles.some((file) => file.name === doc.base_url),
-          ) || []
-
-        const baseUrlMap = organizeDocsByBaseUrl(matchingDocsInProgress)
-
-        const additionalFiles = createAdditionalFileEntries(
-          baseUrlMap,
-          currentFiles,
-          matchingDocsInProgress,
-        )
-
-        const updatedFiles = updateExistingFiles(
-          currentFiles,
-          matchingDocsInProgress,
-        )
-
-        return [...updatedFiles, ...additionalFiles]
-      }
-
-      // Diff against a snapshot so the table is only refreshed when this tick
-      // actually changed something (statuses or new entries).
-      const snapshot = uploadFilesRef.current
-      const nextFiles = computeNextFiles(snapshot)
-      const changed =
-        nextFiles.length !== snapshot.length ||
-        nextFiles.some((file, i) => file !== snapshot[i])
-      const hasErrorTransition = nextFiles.some(
-        (file, i) => file !== snapshot[i] && file.status === 'error',
+      const matchingDocsInProgress = status.inProgress.filter((doc) =>
+        currentFiles.some((file) => file.name === doc.base_url),
       )
 
-      setUploadFiles((prev) => computeNextFiles(prev))
+      const additionalFiles = createAdditionalFileEntries(
+        organizeDocsByBaseUrl(matchingDocsInProgress),
+        currentFiles,
+        matchingDocsInProgress,
+      )
 
-      if (changed) {
-        void queryClient.invalidateQueries({
-          queryKey: ['documents', project_name],
-        })
-      }
-      if (hasErrorTransition) {
-        void queryClient.invalidateQueries({
-          queryKey: ['failedDocuments', project_name],
-        })
-      }
-  }
+      const updatedFiles = updateExistingFiles(
+        currentFiles,
+        matchingDocsInProgress,
+      )
+
+      return [...updatedFiles, ...additionalFiles]
+    },
+  })
 
   // if (isLoading) {
   //   return <Skeleton height={200} width={330} radius={'lg'} />

--- a/apps/frontend/src/components/UIUC-Components/GitHubIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/GitHubIngestForm.tsx
@@ -270,16 +270,15 @@ export default function GitHubIngestForm({
               (doc) => doc.base_url === baseUrl,
             )
 
-            const isStillIngesting = matchingDoc !== undefined
-
             urls.forEach((url) => {
               if (
                 !currentFiles.some((file) => file.url === url) &&
                 matchingDoc
               ) {
+                // Only reached when the base URL is still in progress.
                 newFiles.push({
                   name: url,
-                  status: isStillIngesting ? 'ingesting' : 'complete',
+                  status: 'ingesting',
                   type: 'github',
                   url: url,
                 })

--- a/apps/frontend/src/components/UIUC-Components/LargeDropzone.tsx
+++ b/apps/frontend/src/components/UIUC-Components/LargeDropzone.tsx
@@ -1,6 +1,6 @@
 // LargeDropzone.tsx
 import React, { useRef, useState } from 'react'
-import { createStyles, Group, rem, Text } from '@mantine/core'
+import { Group, rem, Text } from '@mantine/core'
 
 import { IconCloudUpload, IconDownload, IconX } from '@tabler/icons-react'
 import { type QueryClient } from '@tanstack/react-query'
@@ -21,13 +21,6 @@ import { type AuthContextProps } from 'react-oidc-context'
 const POLL_INTERVAL_MS = 5000
 
 const isActiveDocument = (file: FileUpload) => isActiveUpload(file, 'document')
-
-const useStyles = createStyles(() => ({
-  wrapper: {
-    position: 'relative',
-    // marginBottom: rem(10),
-  },
-}))
 
 export function LargeDropzone({
   courseName,
@@ -54,7 +47,6 @@ export function LargeDropzone({
   const [uploadInProgress, setUploadInProgress] = useState(false)
   const router = useRouter()
   const isSmallScreen = useMediaQuery('(max-width: 960px)')
-  const { classes } = useStyles()
   const openRef = useRef<() => void>(null)
 
   const uploadToS3 = async (file: File | null, uniqueFileName: string) => {
@@ -254,7 +246,7 @@ export function LargeDropzone({
       >
         {/* TODO: fix large dropzone display across all screens */}
         <div
-          className={classes.wrapper}
+          className="relative"
           style={{
             flex: 1,
             display: 'flex',

--- a/apps/frontend/src/components/UIUC-Components/LargeDropzone.tsx
+++ b/apps/frontend/src/components/UIUC-Components/LargeDropzone.tsx
@@ -1,5 +1,5 @@
 // LargeDropzone.tsx
-import React, { useRef, useState, useEffect } from 'react'
+import React, { useRef, useState } from 'react'
 import { createStyles, Group, rem, Text } from '@mantine/core'
 
 import { IconCloudUpload, IconDownload, IconX } from '@tabler/icons-react'
@@ -10,12 +10,17 @@ import { type CourseMetadata } from '~/types/courseMetadata'
 import SupportedFileUploadTypes from './SupportedFileUploadTypes'
 import { useMediaQuery } from '@mantine/hooks'
 import { callSetCourseMetadata } from '~/utils/apiUtils'
-import { fetchIngestStatus } from '~/utils/ingestStatusClient'
+import { useGatedIngestPoller } from '~/hooks/useGatedIngestPoller'
 import { v4 as uuidv4 } from 'uuid'
 import { type FileUpload } from './UploadNotification'
 import { type AuthContextProps } from 'react-oidc-context'
 
 const POLL_INTERVAL_MS = 5000
+
+/** A document upload this component is still waiting on. */
+const isActiveDocument = (file: FileUpload) =>
+  file.type === 'document' &&
+  (file.status === 'uploading' || file.status === 'ingesting')
 
 const useStyles = createStyles(() => ({
   wrapper: {
@@ -190,120 +195,54 @@ export function LargeDropzone({
     }
   }
 
-  // Poll ingest status only while this component has document uploads in
-  // flight. The tracked filenames are sent as a server-side filter so the
-  // endpoints never return the whole documents table.
-  const isPollingActive = uploadFiles.some(
-    (file) =>
-      file.type === 'document' &&
-      (file.status === 'uploading' || file.status === 'ingesting'),
-  )
-  const uploadFilesRef = useRef(uploadFiles)
-  uploadFilesRef.current = uploadFiles
-  const wasPollingActiveRef = useRef(false)
+  // Poll ingest status only while document uploads are in flight, sending the
+  // tracked filenames as a server-side filter so the endpoints never return
+  // the whole documents table.
+  useGatedIngestPoller({
+    courseName,
+    uploadFiles,
+    setUploadFiles,
+    queryClient,
+    type: 'document',
+    intervalMs: POLL_INTERVAL_MS,
+    buildFilter: (files) => ({
+      filenames: files
+        .filter((file) => isActiveDocument(file))
+        .map((file) => file.name),
+    }),
+    applyStatus: (status, files) => {
+      const inProgressNames = new Set(
+        status.inProgress.map((doc) => doc.readable_filename),
+      )
+      const completedNames = new Set(
+        status.completed.map((doc) => doc.readable_filename),
+      )
 
-  useEffect(() => {
-    if (!isPollingActive) {
-      if (wasPollingActiveRef.current) {
-        // Gate just closed — final refresh as a backstop for any invalidation
-        // missed by per-tick diffs (e.g. errors set outside the poller).
-        wasPollingActiveRef.current = false
-        void queryClient.invalidateQueries({
-          queryKey: ['documents', courseName],
-        })
-        void queryClient.invalidateQueries({
-          queryKey: ['failedDocuments', courseName],
-        })
-      }
-      return
-    }
-    wasPollingActiveRef.current = true
-    let inFlight = false
+      return files.map((file) => {
+        // Only files the tick actually asked about may be re-classified;
+        // anything else is absent from the results for a benign reason.
+        if (!isActiveDocument(file)) return file
 
-    const checkIngestStatus = async () => {
-      if (inFlight) return
-      inFlight = true
-      try {
-        const trackedNames = uploadFilesRef.current
-          .filter(
-            (file) =>
-              file.type === 'document' &&
-              (file.status === 'uploading' || file.status === 'ingesting'),
-          )
-          .map((file) => file.name)
-        if (trackedNames.length === 0) return
-
-        const status = await fetchIngestStatus(courseName, {
-          filenames: trackedNames,
-        })
-        // A failed request must not be read as "file vanished" — skip the tick.
-        if (!status) return
-
-        const inProgressNames = new Set(
-          status.inProgress.map((doc) => doc.readable_filename),
-        )
-        const completedNames = new Set(
-          status.completed.map((doc) => doc.readable_filename),
-        )
-
-        const mapFile = (file: FileUpload): FileUpload => {
-          if (file.type !== 'document') return file
-
-          if (file.status === 'uploading') {
-            if (inProgressNames.has(file.name)) {
-              return { ...file, status: 'ingesting' }
-            }
-            // Ingest can happen very quickly, check if completed also
-            if (completedNames.has(file.name)) {
-              return { ...file, status: 'complete' }
-            }
-          } else if (file.status === 'ingesting') {
-            if (!inProgressNames.has(file.name)) {
-              return {
-                ...file,
-                status: completedNames.has(file.name)
-                  ? ('complete' as const)
-                  : ('error' as const),
-              }
-            }
+        if (file.status === 'uploading') {
+          if (inProgressNames.has(file.name)) {
+            return { ...file, status: 'ingesting' }
           }
-          return file
+          // Ingest can happen very quickly, check if completed also
+          if (completedNames.has(file.name)) {
+            return { ...file, status: 'complete' }
+          }
+        } else if (!inProgressNames.has(file.name)) {
+          return {
+            ...file,
+            status: completedNames.has(file.name)
+              ? ('complete' as const)
+              : ('error' as const),
+          }
         }
-
-        const snapshot = uploadFilesRef.current
-        const mapped = snapshot.map(mapFile)
-        const hasCompleteTransition = mapped.some(
-          (file, i) => file !== snapshot[i] && file.status === 'complete',
-        )
-        const hasErrorTransition = mapped.some(
-          (file, i) => file !== snapshot[i] && file.status === 'error',
-        )
-
-        setUploadFiles((prev) => prev.map(mapFile))
-
-        if (hasCompleteTransition) {
-          void queryClient.invalidateQueries({
-            queryKey: ['documents', courseName],
-          })
-        }
-        if (hasErrorTransition) {
-          void queryClient.invalidateQueries({
-            queryKey: ['failedDocuments', courseName],
-          })
-        }
-      } catch (error) {
-        console.error('Error checking ingest status:', error)
-      } finally {
-        inFlight = false
-      }
-    }
-
-    const intervalId = setInterval(checkIngestStatus, POLL_INTERVAL_MS)
-
-    return () => {
-      clearInterval(intervalId)
-    }
-  }, [isPollingActive, courseName])
+        return file
+      })
+    },
+  })
 
   return (
     <>

--- a/apps/frontend/src/components/UIUC-Components/LargeDropzone.tsx
+++ b/apps/frontend/src/components/UIUC-Components/LargeDropzone.tsx
@@ -10,17 +10,17 @@ import { type CourseMetadata } from '~/types/courseMetadata'
 import SupportedFileUploadTypes from './SupportedFileUploadTypes'
 import { useMediaQuery } from '@mantine/hooks'
 import { callSetCourseMetadata } from '~/utils/apiUtils'
-import { useGatedIngestPoller } from '~/hooks/useGatedIngestPoller'
+import {
+  isActiveUpload,
+  useGatedIngestPoller,
+} from '~/hooks/useGatedIngestPoller'
 import { v4 as uuidv4 } from 'uuid'
 import { type FileUpload } from './UploadNotification'
 import { type AuthContextProps } from 'react-oidc-context'
 
 const POLL_INTERVAL_MS = 5000
 
-/** A document upload this component is still waiting on. */
-const isActiveDocument = (file: FileUpload) =>
-  file.type === 'document' &&
-  (file.status === 'uploading' || file.status === 'ingesting')
+const isActiveDocument = (file: FileUpload) => isActiveUpload(file, 'document')
 
 const useStyles = createStyles(() => ({
   wrapper: {

--- a/apps/frontend/src/components/UIUC-Components/LargeDropzone.tsx
+++ b/apps/frontend/src/components/UIUC-Components/LargeDropzone.tsx
@@ -1,107 +1,57 @@
 // LargeDropzone.tsx
 import React, { useRef, useState, useEffect } from 'react'
-import {
-  createStyles,
-  Group,
-  rem,
-  Text,
-  Title,
-  Paper,
-  Progress,
-  // useMantineTheme,
-} from '@mantine/core'
+import { createStyles, Group, rem, Text } from '@mantine/core'
 
-import {
-  IconAlertCircle,
-  IconCheck,
-  IconCloudUpload,
-  IconDownload,
-  IconFileUpload,
-  IconX,
-} from '@tabler/icons-react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { IconCloudUpload, IconDownload, IconX } from '@tabler/icons-react'
+import { type QueryClient } from '@tanstack/react-query'
 import { Dropzone } from '@mantine/dropzone'
 import { useRouter } from 'next/router'
 import { type CourseMetadata } from '~/types/courseMetadata'
 import SupportedFileUploadTypes from './SupportedFileUploadTypes'
 import { useMediaQuery } from '@mantine/hooks'
 import { callSetCourseMetadata } from '~/utils/apiUtils'
+import { fetchIngestStatus } from '~/utils/ingestStatusClient'
 import { v4 as uuidv4 } from 'uuid'
 import { type FileUpload } from './UploadNotification'
 import { type AuthContextProps } from 'react-oidc-context'
 
-const useStyles = createStyles((theme) => ({
+const POLL_INTERVAL_MS = 5000
+
+const useStyles = createStyles(() => ({
   wrapper: {
     position: 'relative',
     // marginBottom: rem(10),
-  },
-
-  icon: {
-    color:
-      theme.colorScheme === 'dark'
-        ? theme.colors.dark[3]
-        : theme.colors.gray[4],
-  },
-
-  control: {
-    position: 'absolute',
-    width: rem(250),
-    left: `calc(50% - ${rem(125)})`,
-    bottom: rem(-20),
-  },
-  dropzone: {
-    backgroundPosition: '0% 0%',
-    '&:hover': {
-      backgroundPosition: '100% 100%',
-      background: 'linear-gradient(135deg, #2a2a40 0%, #1c1c2e 100%)',
-    },
   },
 }))
 
 export function LargeDropzone({
   courseName,
   current_user_email,
-  redirect_to_gpt_4 = true,
   isDisabled = false,
   courseMetadata,
   is_new_course,
+  uploadFiles,
   setUploadFiles,
+  queryClient,
   auth,
 }: {
   courseName: string
   current_user_email: string
-  redirect_to_gpt_4?: boolean
   isDisabled?: boolean
   courseMetadata: CourseMetadata
   is_new_course: boolean
+  uploadFiles: FileUpload[]
   setUploadFiles: React.Dispatch<React.SetStateAction<FileUpload[]>>
+  queryClient: QueryClient
   auth: AuthContextProps
 }) {
   // upload-in-progress spinner control
   const [uploadInProgress, setUploadInProgress] = useState(false)
-  const [uploadComplete, setUploadComplete] = useState(false)
-  const [successfulUploads, setSuccessfulUploads] = useState(0)
   const router = useRouter()
   const isSmallScreen = useMediaQuery('(max-width: 960px)')
-  const { classes, theme } = useStyles()
+  const { classes } = useStyles()
   const openRef = useRef<() => void>(null)
-  const [files, setFiles] = useState<File[]>([])
 
-  const refreshOrRedirect = async (redirect_to_gpt_4: boolean) => {
-    if (is_new_course) {
-      // refresh current page
-      await new Promise((resolve) => setTimeout(resolve, 200))
-      await router.push(`/${courseName}/dashboard`)
-      return
-    }
-
-    if (redirect_to_gpt_4) {
-      await router.push(`/${courseName}/chat`)
-    }
-    // refresh current page
-    await new Promise((resolve) => setTimeout(resolve, 200))
-    await router.reload()
-  }
   const uploadToS3 = async (file: File | null, uniqueFileName: string) => {
     if (!file) return
 
@@ -159,10 +109,7 @@ export function LargeDropzone({
     if (!files) return
     files = files.filter((file) => file !== null)
 
-    setFiles(files)
-    setSuccessfulUploads(0)
     setUploadInProgress(true)
-    setUploadComplete(false)
 
     // Initialize file upload status
     const initialFileUploads = files.map((file) => {
@@ -195,7 +142,7 @@ export function LargeDropzone({
     }
 
     // Process files in parallel
-    const allSuccessOrFail = await Promise.all(
+    await Promise.all(
       files.map(async (file) => {
         const extension = file.name.slice(file.name.lastIndexOf('.'))
         const nameWithoutExtension = file.name
@@ -206,7 +153,6 @@ export function LargeDropzone({
 
         try {
           await uploadToS3(file, uniqueFileName)
-          setSuccessfulUploads((prev) => prev + 1)
 
           const response = await fetch(`/api/UIUC-api/ingest`, {
             method: 'POST',
@@ -235,104 +181,129 @@ export function LargeDropzone({
       }),
     )
 
-    setSuccessfulUploads(files.length)
-    setUploadComplete(true)
-
-    // Process results
-    const resultSummary = allSuccessOrFail.reduce(
-      (acc: { success_ingest: any[]; failure_ingest: any[] }, curr) => {
-        if (curr.ok) acc.success_ingest.push(curr)
-        else acc.failure_ingest.push(curr)
-        return acc
-      },
-      { success_ingest: [], failure_ingest: [] },
-    )
-
     setUploadInProgress(false)
 
     if (is_new_course) {
-      await refreshOrRedirect(redirect_to_gpt_4)
+      // refresh current page
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      await router.push(`/${courseName}/dashboard`)
     }
   }
+
+  // Poll ingest status only while this component has document uploads in
+  // flight. The tracked filenames are sent as a server-side filter so the
+  // endpoints never return the whole documents table.
+  const isPollingActive = uploadFiles.some(
+    (file) =>
+      file.type === 'document' &&
+      (file.status === 'uploading' || file.status === 'ingesting'),
+  )
+  const uploadFilesRef = useRef(uploadFiles)
+  uploadFilesRef.current = uploadFiles
+  const wasPollingActiveRef = useRef(false)
+
   useEffect(() => {
-    let pollInterval = 9000 // Start with a slower interval
-    const MIN_INTERVAL = 1000 // Fast polling when active
-    const MAX_INTERVAL = 20000 // Slow polling when inactive
-    let consecutiveEmptyPolls = 0
+    if (!isPollingActive) {
+      if (wasPollingActiveRef.current) {
+        // Gate just closed — final refresh as a backstop for any invalidation
+        // missed by per-tick diffs (e.g. errors set outside the poller).
+        wasPollingActiveRef.current = false
+        void queryClient.invalidateQueries({
+          queryKey: ['documents', courseName],
+        })
+        void queryClient.invalidateQueries({
+          queryKey: ['failedDocuments', courseName],
+        })
+      }
+      return
+    }
+    wasPollingActiveRef.current = true
+    let inFlight = false
 
     const checkIngestStatus = async () => {
-      const response = await fetch(
-        `/api/materialsTable/docsInProgress?course_name=${courseName}`,
-      )
-      const data = await response.json()
+      if (inFlight) return
+      inFlight = true
+      try {
+        const trackedNames = uploadFilesRef.current
+          .filter(
+            (file) =>
+              file.type === 'document' &&
+              (file.status === 'uploading' || file.status === 'ingesting'),
+          )
+          .map((file) => file.name)
+        if (trackedNames.length === 0) return
 
-      const docsResponse = await fetch(
-        `/api/materialsTable/successDocs?course_name=${courseName}`,
-      )
-      const docsData = await docsResponse.json()
-      // Adjust polling interval based on activity
-      if (data.documents.length > 0) {
-        pollInterval = MIN_INTERVAL
-        consecutiveEmptyPolls = 0
-      } else {
-        consecutiveEmptyPolls++
-        if (consecutiveEmptyPolls >= 3) {
-          // After 3 empty polls, slow down
-          pollInterval = Math.min(pollInterval * 1.5, MAX_INTERVAL)
-        }
-      }
+        const status = await fetchIngestStatus(courseName, {
+          filenames: trackedNames,
+        })
+        // A failed request must not be read as "file vanished" — skip the tick.
+        if (!status) return
 
-      setUploadFiles((prev) => {
-        return prev.map((file) => {
+        const inProgressNames = new Set(
+          status.inProgress.map((doc) => doc.readable_filename),
+        )
+        const completedNames = new Set(
+          status.completed.map((doc) => doc.readable_filename),
+        )
+
+        const mapFile = (file: FileUpload): FileUpload => {
           if (file.type !== 'document') return file
 
           if (file.status === 'uploading') {
-            const isIngesting = data?.documents?.some(
-              (doc: { readable_filename: string }) =>
-                doc.readable_filename === file.name,
-            )
-            if (isIngesting) {
+            if (inProgressNames.has(file.name)) {
               return { ...file, status: 'ingesting' }
-            } else {
-              // Ingest can happen very quickly, check if completed also
-              const isInCompletedDocs = docsData?.documents?.some(
-                (doc: { readable_filename: string }) =>
-                  doc.readable_filename === file.name,
-              )
-              if (isInCompletedDocs) {
-                return { ...file, status: 'complete' }
-              }
+            }
+            // Ingest can happen very quickly, check if completed also
+            if (completedNames.has(file.name)) {
+              return { ...file, status: 'complete' }
             }
           } else if (file.status === 'ingesting') {
-            const isStillIngesting = data?.documents?.some(
-              (doc: { readable_filename: string }) =>
-                doc.readable_filename === file.name,
-            )
-
-            if (!isStillIngesting) {
-              const isInCompletedDocs = docsData?.documents?.some(
-                (doc: { readable_filename: string }) =>
-                  doc.readable_filename === file.name,
-              )
+            if (!inProgressNames.has(file.name)) {
               return {
                 ...file,
-                status: isInCompletedDocs
+                status: completedNames.has(file.name)
                   ? ('complete' as const)
                   : ('error' as const),
               }
             }
           }
           return file
-        })
-      })
+        }
+
+        const snapshot = uploadFilesRef.current
+        const mapped = snapshot.map(mapFile)
+        const hasCompleteTransition = mapped.some(
+          (file, i) => file !== snapshot[i] && file.status === 'complete',
+        )
+        const hasErrorTransition = mapped.some(
+          (file, i) => file !== snapshot[i] && file.status === 'error',
+        )
+
+        setUploadFiles((prev) => prev.map(mapFile))
+
+        if (hasCompleteTransition) {
+          void queryClient.invalidateQueries({
+            queryKey: ['documents', courseName],
+          })
+        }
+        if (hasErrorTransition) {
+          void queryClient.invalidateQueries({
+            queryKey: ['failedDocuments', courseName],
+          })
+        }
+      } catch (error) {
+        console.error('Error checking ingest status:', error)
+      } finally {
+        inFlight = false
+      }
     }
 
-    const intervalId = setInterval(checkIngestStatus, pollInterval)
+    const intervalId = setInterval(checkIngestStatus, POLL_INTERVAL_MS)
 
     return () => {
       clearInterval(intervalId)
     }
-  }, [courseName])
+  }, [isPollingActive, courseName])
 
   return (
     <>
@@ -494,23 +465,6 @@ export function LargeDropzone({
               </div>
             </div>
           </Dropzone>
-          {/* {uploadInProgress && (
-            <div className="flex flex-col items-center justify-center px-4 text-center">
-              <Title
-                order={4}
-                style={{
-                  marginTop: 10,
-                  color: '#B22222',
-                  fontSize: isSmallScreen ? '0.9rem' : '1rem',
-                  lineHeight: '1.4',
-                }}
-              >
-                Remain on this page until upload is complete
-                <br />
-                or ingest will fail.
-              </Title>
-            </div>
-          )} */}
         </div>
       </div>
     </>

--- a/apps/frontend/src/components/UIUC-Components/LargeDropzone.tsx
+++ b/apps/frontend/src/components/UIUC-Components/LargeDropzone.tsx
@@ -164,7 +164,6 @@ export function LargeDropzone({
           })
           const res = await response.json()
           console.debug('Ingest submitted...', res)
-          return { ok: true, s3_path: file.name }
         } catch (error) {
           console.error('Error during file upload or ingest:', error)
           // Update file status to error so it doesn't block navigation
@@ -173,7 +172,6 @@ export function LargeDropzone({
               f.name === uniqueReadableFileName ? { ...f, status: 'error' } : f,
             ),
           )
-          return { ok: false, s3_path: file.name }
         }
       }),
     )

--- a/apps/frontend/src/components/UIUC-Components/MITIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/MITIngestForm.tsx
@@ -23,6 +23,7 @@ export default function MITIngestForm({
   queryClient: QueryClient
 }): JSX.Element {
   const [isUrlValid, setIsUrlValid] = useState(false)
+  const delayedInvalidateRef = useRef<ReturnType<typeof setTimeout>>()
   const [url, setUrl] = useState('')
   const [maxUrls, setMaxUrls] = useState('50')
   const [open, setOpen] = useState(false)
@@ -123,7 +124,6 @@ export default function MITIngestForm({
     maxDepth: { error: false, message: '' },
   })
 
-  const delayedInvalidateRef = useRef<ReturnType<typeof setTimeout>>()
   useEffect(() => {
     return () => {
       if (delayedInvalidateRef.current) {

--- a/apps/frontend/src/components/UIUC-Components/MITIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/MITIngestForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Text, Card, Button, Input, Image } from '@mantine/core'
 import { IconArrowRight } from '@tabler/icons-react'
 import { motion } from 'framer-motion'
@@ -16,12 +16,12 @@ import { type QueryClient } from '@tanstack/react-query'
 export default function MITIngestForm({
   project_name,
   setUploadFiles,
+  queryClient,
 }: {
   project_name: string
   setUploadFiles: React.Dispatch<React.SetStateAction<FileUpload[]>>
   queryClient: QueryClient
 }): JSX.Element {
-  const [isUrlUpdated, setIsUrlUpdated] = useState(false)
   const [isUrlValid, setIsUrlValid] = useState(false)
   const [url, setUrl] = useState('')
   const [maxUrls, setMaxUrls] = useState('50')
@@ -79,6 +79,19 @@ export default function MITIngestForm({
               file.name === url ? { ...file, status: 'complete' } : file,
             ),
           )
+          // Refresh the documents table now, and once more shortly after:
+          // the download API can resolve before all rows land in the DB.
+          void queryClient.invalidateQueries({
+            queryKey: ['documents', project_name],
+          })
+          if (delayedInvalidateRef.current) {
+            clearTimeout(delayedInvalidateRef.current)
+          }
+          delayedInvalidateRef.current = setTimeout(() => {
+            void queryClient.invalidateQueries({
+              queryKey: ['documents', project_name],
+            })
+          }, 10_000)
         } else {
           // downloadMITCourse returned null, treat as error
           setUploadFiles((prevFiles) =>
@@ -104,13 +117,14 @@ export default function MITIngestForm({
     maxDepth: { error: false, message: '' },
   })
 
+  const delayedInvalidateRef = useRef<ReturnType<typeof setTimeout>>()
   useEffect(() => {
-    if (url && url.length > 0 && validateUrl(url)) {
-      setIsUrlUpdated(true)
-    } else {
-      setIsUrlUpdated(false)
+    return () => {
+      if (delayedInvalidateRef.current) {
+        clearTimeout(delayedInvalidateRef.current)
+      }
     }
-  }, [url])
+  }, [])
 
   return (
     <motion.div layout>
@@ -121,7 +135,6 @@ export default function MITIngestForm({
           if (!isOpen) {
             setUrl('')
             setIsUrlValid(false)
-            setIsUrlUpdated(false)
             setMaxUrls('50')
           }
         }}

--- a/apps/frontend/src/components/UIUC-Components/MITIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/MITIngestForm.tsx
@@ -99,6 +99,9 @@ export default function MITIngestForm({
               file.name === url ? { ...file, status: 'error' } : file,
             ),
           )
+          void queryClient.invalidateQueries({
+            queryKey: ['failedDocuments', project_name],
+          })
         }
       } catch (error) {
         console.error('Error during MIT course import:', error)
@@ -107,6 +110,9 @@ export default function MITIngestForm({
             file.name === url ? { ...file, status: 'error' } : file,
           ),
         )
+        void queryClient.invalidateQueries({
+          queryKey: ['failedDocuments', project_name],
+        })
       }
     } else {
       alert('Invalid URL (please include https://)')

--- a/apps/frontend/src/components/UIUC-Components/MakeNewCoursePage.tsx
+++ b/apps/frontend/src/components/UIUC-Components/MakeNewCoursePage.tsx
@@ -171,6 +171,7 @@ const MakeNewCoursePage = ({
     <StepUpload
       key="upload"
       project_name={projectName}
+      uploadFiles={uploadFiles}
       setUploadFiles={handleSetUploadFiles}
       courseMetadata={
         queryClient.getQueryData(['courseMetadata', projectName]) as

--- a/apps/frontend/src/components/UIUC-Components/MakeNewCoursePageSteps/StepUpload.tsx
+++ b/apps/frontend/src/components/UIUC-Components/MakeNewCoursePageSteps/StepUpload.tsx
@@ -16,12 +16,14 @@ import { type CourseMetadata } from '~/types/courseMetadata'
 
 interface StepUploadProps {
   project_name: string
+  uploadFiles: FileUpload[]
   setUploadFiles: React.Dispatch<React.SetStateAction<FileUpload[]>>
   courseMetadata?: CourseMetadata
 }
 
 const StepUpload = ({
   project_name,
+  uploadFiles,
   setUploadFiles,
   courseMetadata,
 }: StepUploadProps) => {
@@ -81,12 +83,14 @@ const StepUpload = ({
 
             <WebsiteIngestForm
               project_name={project_name}
+              uploadFiles={uploadFiles}
               setUploadFiles={setUploadFiles}
               queryClient={queryClient}
             />
 
             <GitHubIngestForm
               project_name={project_name}
+              uploadFiles={uploadFiles}
               setUploadFiles={setUploadFiles}
               queryClient={queryClient}
             />
@@ -107,10 +111,11 @@ const StepUpload = ({
           <LargeDropzone
             courseName={project_name}
             current_user_email={auth.user?.profile.email || ''}
-            redirect_to_gpt_4={false}
             isDisabled={false}
             is_new_course={false}
+            uploadFiles={uploadFiles}
             setUploadFiles={setUploadFiles}
+            queryClient={queryClient}
             courseMetadata={courseMetadata || defaultMetadata}
             auth={auth}
           />

--- a/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
+++ b/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
@@ -67,9 +67,9 @@ const GlobalStyle = createGlobalStyle`
 
 const PAGE_SIZE = 100
 
-// The table refreshes on a slow timer (plus window-focus refetch and the
+// The table refreshes on a slow interval (plus window-focus refetch and the
 // event-driven invalidations fired by the upload pollers); the refresh button
-// refetches immediately and restarts this countdown.
+// refetches immediately, which also restarts this countdown.
 const TABLE_REFRESH_INTERVAL_MS = 5 * 60_000
 
 const dataTableTitleStyles = {
@@ -175,9 +175,9 @@ export function ProjectFilesTable({
     isLoading: isLoadingDocuments,
     isError: isErrorDocuments,
     error: documentsError,
-    isFetching: isFetchingDocuments,
     refetch: refetchDocuments,
   } = useQuery({
+    refetchInterval: TABLE_REFRESH_INTERVAL_MS,
     queryKey: [
       'documents',
       course_name,
@@ -209,9 +209,9 @@ export function ProjectFilesTable({
     isLoading: isLoadingFailedDocuments,
     isError: isErrorFailedDocuments,
     error: failedDocumentsError,
-    isFetching: isFetchingFailedDocuments,
     refetch: refetchFailedDocuments,
   } = useQuery({
+    refetchInterval: TABLE_REFRESH_INTERVAL_MS,
     queryKey: [
       'failedDocuments',
       course_name,
@@ -243,21 +243,15 @@ export function ProjectFilesTable({
     refetch: refetchDocumentGroups,
   } = useFetchDocumentGroups(course_name)
 
-  // Slow auto-refresh timer. Bumping refreshResetKey clears and re-arms the
-  // interval so a manual refresh restarts the countdown.
-  const [refreshResetKey, setRefreshResetKey] = useState(0)
-  useEffect(() => {
-    const intervalId = setInterval(() => {
-      void refetchDocuments()
-      void refetchFailedDocuments()
-    }, TABLE_REFRESH_INTERVAL_MS)
-    return () => clearInterval(intervalId)
-  }, [refreshResetKey, course_name])
-
+  // react-query re-arms refetchInterval after every successful fetch, so a
+  // manual refresh also restarts the countdown.
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false)
   const handleManualRefresh = () => {
-    void refetchDocuments()
-    void refetchFailedDocuments()
-    setRefreshResetKey((key) => key + 1)
+    setIsManualRefreshing(true)
+    void Promise.allSettled([
+      refetchDocuments(),
+      refetchFailedDocuments(),
+    ]).finally(() => setIsManualRefreshing(false))
   }
 
   useEffect(() => {
@@ -609,7 +603,7 @@ export function ProjectFilesTable({
                 aria-label="Refresh documents table"
                 size="lg"
                 variant="subtle"
-                loading={isFetchingDocuments || isFetchingFailedDocuments}
+                loading={isManualRefreshing}
                 className="text-[--foreground] transition-colors duration-300 hover:bg-[--dashboard-background-faded] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[--dashboard-button]"
               >
                 <IconRefresh size={20} />
@@ -1111,8 +1105,8 @@ export function ProjectFilesTable({
               width: isBetweenSmallAndMediumScreen
                 ? 80
                 : isSmallScreen
-                  ? 60
-                  : 130,
+                ? 60
+                : 130,
               sortable: true,
               // TODO: Think about how to allow filtering on date... need different UI to select date range
               // filter: (

--- a/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
+++ b/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
@@ -25,6 +25,7 @@ import {
   IconCheck,
   IconCopy,
   IconEye,
+  IconRefresh,
   IconTrash,
   IconX,
 } from '@tabler/icons-react'
@@ -65,6 +66,11 @@ const GlobalStyle = createGlobalStyle`
 `
 
 const PAGE_SIZE = 100
+
+// The table refreshes on a slow timer (plus window-focus refetch and the
+// event-driven invalidations fired by the upload pollers); the refresh button
+// refetches immediately and restarts this countdown.
+const TABLE_REFRESH_INTERVAL_MS = 5 * 60_000
 
 const dataTableTitleStyles = {
   color: 'var(--table-header)',
@@ -169,9 +175,9 @@ export function ProjectFilesTable({
     isLoading: isLoadingDocuments,
     isError: isErrorDocuments,
     error: documentsError,
+    isFetching: isFetchingDocuments,
     refetch: refetchDocuments,
   } = useQuery({
-    refetchInterval: 12_000,
     queryKey: [
       'documents',
       course_name,
@@ -203,8 +209,9 @@ export function ProjectFilesTable({
     isLoading: isLoadingFailedDocuments,
     isError: isErrorFailedDocuments,
     error: failedDocumentsError,
+    isFetching: isFetchingFailedDocuments,
+    refetch: refetchFailedDocuments,
   } = useQuery({
-    refetchInterval: 20_000,
     queryKey: [
       'failedDocuments',
       course_name,
@@ -235,6 +242,23 @@ export function ProjectFilesTable({
     isError: isErrorDocumentGroups,
     refetch: refetchDocumentGroups,
   } = useFetchDocumentGroups(course_name)
+
+  // Slow auto-refresh timer. Bumping refreshResetKey clears and re-arms the
+  // interval so a manual refresh restarts the countdown.
+  const [refreshResetKey, setRefreshResetKey] = useState(0)
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      void refetchDocuments()
+      void refetchFailedDocuments()
+    }, TABLE_REFRESH_INTERVAL_MS)
+    return () => clearInterval(intervalId)
+  }, [refreshResetKey, course_name])
+
+  const handleManualRefresh = () => {
+    void refetchDocuments()
+    void refetchFailedDocuments()
+    setRefreshResetKey((key) => key + 1)
+  }
 
   useEffect(() => {
     if (tabValue === 'failed') {
@@ -569,6 +593,28 @@ export function ProjectFilesTable({
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
+            <Tooltip
+              label="Table auto-refreshes every 5 minutes (and when you return to this tab). Click to refresh now."
+              position="top"
+              withArrow
+              multiline
+              width={260}
+              style={{
+                color: 'var(--tooltip)',
+                backgroundColor: 'var(--tooltip-background)',
+              }}
+            >
+              <ActionIcon
+                onClick={handleManualRefresh}
+                aria-label="Refresh documents table"
+                size="lg"
+                variant="subtle"
+                loading={isFetchingDocuments || isFetchingFailedDocuments}
+                className="text-[--foreground] transition-colors duration-300 hover:bg-[--dashboard-background-faded] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[--dashboard-button]"
+              >
+                <IconRefresh size={20} />
+              </ActionIcon>
+            </Tooltip>
             {tabValue !== 'failed' && (
               <Button
                 onClick={() => setExportModalOpened(true)}

--- a/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
+++ b/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
@@ -1106,8 +1106,8 @@ export function ProjectFilesTable({
               width: isBetweenSmallAndMediumScreen
                 ? 80
                 : isSmallScreen
-                ? 60
-                : 130,
+                  ? 60
+                  : 130,
               sortable: true,
               // TODO: Think about how to allow filtering on date... need different UI to select date range
               // filter: (

--- a/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
+++ b/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
@@ -251,6 +251,7 @@ export function ProjectFilesTable({
     void Promise.allSettled([
       refetchDocuments(),
       refetchFailedDocuments(),
+      refetchDocumentGroups(),
     ]).finally(() => setIsManualRefreshing(false))
   }
 

--- a/apps/frontend/src/components/UIUC-Components/UploadCard.tsx
+++ b/apps/frontend/src/components/UIUC-Components/UploadCard.tsx
@@ -220,11 +220,12 @@ export const UploadCard = memo(function UploadCard({
             <LargeDropzone
               courseName={projectName}
               current_user_email={current_user_email as string}
-              redirect_to_gpt_4={false}
               isDisabled={false}
               courseMetadata={metadata as CourseMetadata}
               is_new_course={false}
+              uploadFiles={uploadFiles}
               setUploadFiles={handleSetUploadFiles}
+              queryClient={queryClient}
               auth={auth}
             />
           </div>
@@ -246,12 +247,14 @@ export const UploadCard = memo(function UploadCard({
 
             <WebsiteIngestForm
               project_name={projectName}
+              uploadFiles={uploadFiles}
               setUploadFiles={handleSetUploadFiles}
               queryClient={queryClient}
             />
 
             <GitHubIngestForm
               project_name={projectName}
+              uploadFiles={uploadFiles}
               setUploadFiles={handleSetUploadFiles}
               queryClient={queryClient}
             />

--- a/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useState } from 'react'
 import {
   Text,
   Card,
@@ -37,12 +37,14 @@ import axios from 'axios'
 import { Montserrat } from 'next/font/google'
 import { type FileUpload } from './UploadNotification'
 import { type QueryClient } from '@tanstack/react-query'
-import { fetchIngestStatus } from '~/utils/ingestStatusClient'
+import { useGatedIngestPoller } from '~/hooks/useGatedIngestPoller'
 
 const montserrat_med = Montserrat({
   weight: '500',
   subsets: ['latin'],
 })
+
+const POLL_INTERVAL_MS = 3000
 
 // Strip trailing slashes so the user-entered URL and the backend-stored
 // base_url compare equal even when one has a trailing slash and the
@@ -175,76 +177,27 @@ export default function WebsiteIngestForm({
     await new Promise((resolve) => setTimeout(resolve, 8000))
   }
 
-  // Poll ingest status only while webscrape uploads are tracked and active.
-  // The tracked base URLs are sent as a server-side filter so the endpoints
-  // never return the whole documents table.
-  const isPollingActive = uploadFiles.some(
-    (file) =>
-      file.type === 'webscrape' &&
-      (file.status === 'uploading' || file.status === 'ingesting'),
-  )
-  const uploadFilesRef = useRef(uploadFiles)
-  uploadFilesRef.current = uploadFiles
-  const wasPollingActiveRef = useRef(false)
-
-  useEffect(() => {
-    if (!isPollingActive) {
-      if (wasPollingActiveRef.current) {
-        // Gate just closed — final refresh as a backstop for any invalidation
-        // missed by per-tick diffs.
-        wasPollingActiveRef.current = false
-        void queryClient.invalidateQueries({
-          queryKey: ['documents', project_name],
-        })
-        void queryClient.invalidateQueries({
-          queryKey: ['failedDocuments', project_name],
-        })
-      }
-      return
-    }
-    wasPollingActiveRef.current = true
-    let inFlight = false
-
-    const checkIngestStatus = async () => {
-      if (inFlight) return
-      inFlight = true
-      try {
-        // Filter on the base URLs of ALL tracked base entries regardless of
-        // their status: child rows carry the base's base_url, so this returns
-        // every row the matching below needs — including children that are
-        // still resolving after the base entry itself went terminal.
-        const trackedBaseUrls = uploadFilesRef.current
-          .filter((file) => file.type === 'webscrape' && file.isBaseUrl)
-          .map((file) => normalizeUrl(file.url ?? file.name))
-          .filter((baseUrl) => baseUrl.length > 0)
-
-        const status = await fetchIngestStatus(project_name, {
-          base_urls: trackedBaseUrls,
-        })
-        // A failed request must not be read as "doc vanished" — skip the tick.
-        if (!status) return
-
-        const data = { documents: status.inProgress }
-        const docsData = { documents: status.completed }
-
-        applyIngestStatus(data, docsData)
-      } catch (error) {
-        console.error('Error checking ingest status:', error)
-      } finally {
-        inFlight = false
-      }
-    }
-
-    const interval = setInterval(checkIngestStatus, 3000)
-    return () => {
-      clearInterval(interval)
-    }
-  }, [isPollingActive, project_name])
-
-  const applyIngestStatus = (
-    data: { documents: Array<{ base_url: string; url: string }> },
-    docsData: { documents: Array<{ base_url: string; url: string }> },
-  ) => {
+  // Poll ingest status only while webscrape uploads are in flight, sending
+  // the tracked base URLs as a server-side filter so the endpoints never
+  // return the whole documents table.
+  useGatedIngestPoller({
+    courseName: project_name,
+    uploadFiles,
+    setUploadFiles,
+    queryClient,
+    type: 'webscrape',
+    intervalMs: POLL_INTERVAL_MS,
+    // Filter on the base URLs of ALL tracked base entries regardless of their
+    // status: child rows carry the base's base_url, so this returns every row
+    // the matching below needs — including children that are still resolving
+    // after the base entry itself went terminal.
+    buildFilter: (files) => ({
+      base_urls: files
+        .filter((file) => file.type === 'webscrape' && file.isBaseUrl)
+        .map((file) => normalizeUrl(file.url ?? file.name))
+        .filter((baseUrl) => baseUrl.length > 0),
+    }),
+    applyStatus: (status, currentFiles) => {
       const baseUrlMatchesFile = (
         docBaseUrl: string,
         file: FileUpload,
@@ -300,8 +253,8 @@ export default function WebsiteIngestForm({
                   (f) => f.status === 'complete' || f.status === 'error',
                 )
 
-              const isInCompletedDocs = docsData?.documents?.some(
-                (doc: { url: string; base_url?: string }) =>
+              const isInCompletedDocs = status.completed.some(
+                (doc) =>
                   normalizeUrl(doc.url) === normalizeUrl(file.url) ||
                   (file.isBaseUrl &&
                     normalizeUrl(doc.base_url) === normalizeUrl(file.url)),
@@ -376,64 +329,28 @@ export default function WebsiteIngestForm({
         return newFiles
       }
 
-      const computeNextFiles = (currentFiles: FileUpload[]) => {
-        const matchingDocsInProgress =
-          data?.documents?.filter((doc: { base_url: string }) =>
-            currentFiles.some((file) =>
-              baseUrlMatchesFile(doc.base_url, file),
-            ),
-          ) || []
-
-        const matchingSuccessDocs =
-          docsData?.documents?.filter((doc: { base_url: string }) =>
-            currentFiles.some((file) =>
-              baseUrlMatchesFile(doc.base_url, file),
-            ),
-          ) || []
-
-        const inProgressBaseUrlMap = organizeDocsByBaseUrl(
-          matchingDocsInProgress,
-        )
-        const successBaseUrlMap = organizeDocsByBaseUrl(matchingSuccessDocs)
-
-        const additionalFiles = createAdditionalFileEntries(
-          inProgressBaseUrlMap,
-          successBaseUrlMap,
-          currentFiles,
-        )
-
-        const updatedFiles = updateExistingFiles(
-          currentFiles,
-          matchingDocsInProgress,
-        )
-
-        return [...updatedFiles, ...additionalFiles]
-      }
-
-      // Diff against a snapshot so the table is only refreshed when this tick
-      // actually changed something (statuses or new entries).
-      const snapshot = uploadFilesRef.current
-      const nextFiles = computeNextFiles(snapshot)
-      const changed =
-        nextFiles.length !== snapshot.length ||
-        nextFiles.some((file, i) => file !== snapshot[i])
-      const hasErrorTransition = nextFiles.some(
-        (file, i) => file !== snapshot[i] && file.status === 'error',
+      const matchingDocsInProgress = status.inProgress.filter((doc) =>
+        currentFiles.some((file) => baseUrlMatchesFile(doc.base_url, file)),
       )
 
-      setUploadFiles((prev) => computeNextFiles(prev))
+      const matchingSuccessDocs = status.completed.filter((doc) =>
+        currentFiles.some((file) => baseUrlMatchesFile(doc.base_url, file)),
+      )
 
-      if (changed) {
-        void queryClient.invalidateQueries({
-          queryKey: ['documents', project_name],
-        })
-      }
-      if (hasErrorTransition) {
-        void queryClient.invalidateQueries({
-          queryKey: ['failedDocuments', project_name],
-        })
-      }
-  }
+      const additionalFiles = createAdditionalFileEntries(
+        organizeDocsByBaseUrl(matchingDocsInProgress),
+        organizeDocsByBaseUrl(matchingSuccessDocs),
+        currentFiles,
+      )
+
+      const updatedFiles = updateExistingFiles(
+        currentFiles,
+        matchingDocsInProgress,
+      )
+
+      return [...updatedFiles, ...additionalFiles]
+    },
+  })
 
   const scrapeWeb = async (
     url: string | null,

--- a/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import {
   Text,
   Card,
@@ -37,21 +37,29 @@ import axios from 'axios'
 import { Montserrat } from 'next/font/google'
 import { type FileUpload } from './UploadNotification'
 import { type QueryClient } from '@tanstack/react-query'
+import { fetchIngestStatus } from '~/utils/ingestStatusClient'
 
 const montserrat_med = Montserrat({
   weight: '500',
   subsets: ['latin'],
 })
+
+// Strip trailing slashes so the user-entered URL and the backend-stored
+// base_url compare equal even when one has a trailing slash and the
+// other doesn't.
+const normalizeUrl = (url: string | undefined | null) =>
+  (url ?? '').replace(/\/+$/, '')
 export default function WebsiteIngestForm({
   project_name,
+  uploadFiles,
   setUploadFiles,
   queryClient,
 }: {
   project_name: string
+  uploadFiles: FileUpload[]
   setUploadFiles: React.Dispatch<React.SetStateAction<FileUpload[]>>
   queryClient: QueryClient
 }): JSX.Element {
-  const [isUrlUpdated, setIsUrlUpdated] = useState(false)
   const [isUrlValid, setIsUrlValid] = useState(false)
   const [url, setUrl] = useState('')
   const [maxUrls, setMaxUrls] = useState('50')
@@ -151,12 +159,6 @@ export default function WebsiteIngestForm({
             file.name === url ? { ...file, status: 'ingesting' } : file,
           ),
         )
-        // Transition to 'ingesting' status after API call succeeds
-        setUploadFiles((prevFiles) =>
-          prevFiles.map((file) =>
-            file.name === url ? { ...file, status: 'ingesting' } : file,
-          ),
-        )
       } catch (error: unknown) {
         console.error('Error while scraping web:', error)
         setUploadFiles((prevFiles) =>
@@ -173,31 +175,76 @@ export default function WebsiteIngestForm({
     await new Promise((resolve) => setTimeout(resolve, 8000))
   }
 
+  // Poll ingest status only while webscrape uploads are tracked and active.
+  // The tracked base URLs are sent as a server-side filter so the endpoints
+  // never return the whole documents table.
+  const isPollingActive = uploadFiles.some(
+    (file) =>
+      file.type === 'webscrape' &&
+      (file.status === 'uploading' || file.status === 'ingesting'),
+  )
+  const uploadFilesRef = useRef(uploadFiles)
+  uploadFilesRef.current = uploadFiles
+  const wasPollingActiveRef = useRef(false)
+
   useEffect(() => {
-    if (url && url.length > 0 && validateUrl(url)) {
-      setIsUrlUpdated(true)
-    } else {
-      setIsUrlUpdated(false)
+    if (!isPollingActive) {
+      if (wasPollingActiveRef.current) {
+        // Gate just closed — final refresh as a backstop for any invalidation
+        // missed by per-tick diffs.
+        wasPollingActiveRef.current = false
+        void queryClient.invalidateQueries({
+          queryKey: ['documents', project_name],
+        })
+        void queryClient.invalidateQueries({
+          queryKey: ['failedDocuments', project_name],
+        })
+      }
+      return
     }
-  }, [url])
+    wasPollingActiveRef.current = true
+    let inFlight = false
 
-  useEffect(() => {
     const checkIngestStatus = async () => {
-      const response = await fetch(
-        `/api/materialsTable/docsInProgress?course_name=${project_name}`,
-      )
-      const data = await response.json()
-      const docsResponse = await fetch(
-        `/api/materialsTable/successDocs?course_name=${project_name}`,
-      )
-      const docsData = await docsResponse.json()
+      if (inFlight) return
+      inFlight = true
+      try {
+        // Filter on the base URLs of ALL tracked base entries regardless of
+        // their status: child rows carry the base's base_url, so this returns
+        // every row the matching below needs — including children that are
+        // still resolving after the base entry itself went terminal.
+        const trackedBaseUrls = uploadFilesRef.current
+          .filter((file) => file.type === 'webscrape' && file.isBaseUrl)
+          .map((file) => normalizeUrl(file.url ?? file.name))
+          .filter((baseUrl) => baseUrl.length > 0)
 
-      // Strip trailing slashes so the user-entered URL and the backend-stored
-      // base_url compare equal even when one has a trailing slash and the
-      // other doesn't.
-      const normalizeUrl = (url: string | undefined | null) =>
-        (url ?? '').replace(/\/+$/, '')
+        const status = await fetchIngestStatus(project_name, {
+          base_urls: trackedBaseUrls,
+        })
+        // A failed request must not be read as "doc vanished" — skip the tick.
+        if (!status) return
 
+        const data = { documents: status.inProgress }
+        const docsData = { documents: status.completed }
+
+        applyIngestStatus(data, docsData)
+      } catch (error) {
+        console.error('Error checking ingest status:', error)
+      } finally {
+        inFlight = false
+      }
+    }
+
+    const interval = setInterval(checkIngestStatus, 3000)
+    return () => {
+      clearInterval(interval)
+    }
+  }, [isPollingActive, project_name])
+
+  const applyIngestStatus = (
+    data: { documents: Array<{ base_url: string; url: string }> },
+    docsData: { documents: Array<{ base_url: string; url: string }> },
+  ) => {
       const baseUrlMatchesFile = (
         docBaseUrl: string,
         file: FileUpload,
@@ -329,15 +376,19 @@ export default function WebsiteIngestForm({
         return newFiles
       }
 
-      setUploadFiles((prev) => {
+      const computeNextFiles = (currentFiles: FileUpload[]) => {
         const matchingDocsInProgress =
           data?.documents?.filter((doc: { base_url: string }) =>
-            prev.some((file) => baseUrlMatchesFile(doc.base_url, file)),
+            currentFiles.some((file) =>
+              baseUrlMatchesFile(doc.base_url, file),
+            ),
           ) || []
 
         const matchingSuccessDocs =
           docsData?.documents?.filter((doc: { base_url: string }) =>
-            prev.some((file) => baseUrlMatchesFile(doc.base_url, file)),
+            currentFiles.some((file) =>
+              baseUrlMatchesFile(doc.base_url, file),
+            ),
           ) || []
 
         const inProgressBaseUrlMap = organizeDocsByBaseUrl(
@@ -348,24 +399,41 @@ export default function WebsiteIngestForm({
         const additionalFiles = createAdditionalFileEntries(
           inProgressBaseUrlMap,
           successBaseUrlMap,
-          prev,
+          currentFiles,
         )
 
-        const updatedFiles = updateExistingFiles(prev, matchingDocsInProgress)
+        const updatedFiles = updateExistingFiles(
+          currentFiles,
+          matchingDocsInProgress,
+        )
 
         return [...updatedFiles, ...additionalFiles]
-      })
+      }
 
-      await queryClient.invalidateQueries({
-        queryKey: ['documents', project_name],
-      })
-    }
+      // Diff against a snapshot so the table is only refreshed when this tick
+      // actually changed something (statuses or new entries).
+      const snapshot = uploadFilesRef.current
+      const nextFiles = computeNextFiles(snapshot)
+      const changed =
+        nextFiles.length !== snapshot.length ||
+        nextFiles.some((file, i) => file !== snapshot[i])
+      const hasErrorTransition = nextFiles.some(
+        (file, i) => file !== snapshot[i] && file.status === 'error',
+      )
 
-    const interval = setInterval(checkIngestStatus, 3000)
-    return () => {
-      clearInterval(interval)
-    }
-  }, [project_name])
+      setUploadFiles((prev) => computeNextFiles(prev))
+
+      if (changed) {
+        void queryClient.invalidateQueries({
+          queryKey: ['documents', project_name],
+        })
+      }
+      if (hasErrorTransition) {
+        void queryClient.invalidateQueries({
+          queryKey: ['failedDocuments', project_name],
+        })
+      }
+  }
 
   const scrapeWeb = async (
     url: string | null,
@@ -434,7 +502,6 @@ export default function WebsiteIngestForm({
           if (!isOpen) {
             setUrl('')
             setIsUrlValid(false)
-            setIsUrlUpdated(false)
             setMaxUrls('50')
             setInputErrors((prev) => ({
               ...prev,

--- a/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/apps/frontend/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -149,7 +149,7 @@ export default function WebsiteIngestForm({
       setUploadFiles((prevFiles) => [...prevFiles, newFile])
 
       try {
-        const response = await scrapeWeb(
+        await scrapeWeb(
           ingestUrl,
           project_name,
           maxUrls.trim() !== '' ? parseInt(maxUrls) : 50,

--- a/apps/frontend/src/components/UIUC-Components/__tests__/GitHubIngestForm.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/GitHubIngestForm.test.tsx
@@ -88,70 +88,68 @@ describe('GitHubIngestForm', () => {
     // Second poll: completed docs (marks additional entries complete)
     let pollStep = 0
     const requestBodies: any[] = []
-    vi.spyOn(globalThis, 'fetch').mockImplementation(
-      (async (input: any, init?: any) => {
-        const url = String(input?.url ?? input)
-        if (url.includes('/api/materialsTable/')) {
-          requestBodies.push(JSON.parse(init?.body ?? '{}'))
-        }
-        if (url.includes('/api/materialsTable/docsInProgress')) {
-          pollStep += 1
-          if (pollStep === 1) {
-            return new Response(
-              JSON.stringify({
-                documents: [
-                  {
-                    base_url: 'https://github.com/user/repo',
-                    url: 'https://github.com/user/repo/blob/main/README.md',
-                    readable_filename: 'README.md',
-                  },
-                  {
-                    base_url: 'https://github.com/user/repo',
-                    url: 'https://github.com/user/repo/blob/main/docs.md',
-                    readable_filename: 'docs.md',
-                  },
-                ],
-              }),
-              { status: 200, headers: { 'content-type': 'application/json' } },
-            )
-          }
-          return new Response(JSON.stringify({ documents: [] }), {
-            status: 200,
-            headers: { 'content-type': 'application/json' },
-          })
-        }
-        if (url.includes('/api/materialsTable/successDocs')) {
-          if (pollStep <= 1) {
-            return new Response(JSON.stringify({ documents: [] }), {
-              status: 200,
-              headers: { 'content-type': 'application/json' },
-            })
-          }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (
+      input: any,
+      init?: any,
+    ) => {
+      const url = String(input?.url ?? input)
+      if (url.includes('/api/materialsTable/')) {
+        requestBodies.push(JSON.parse(init?.body ?? '{}'))
+      }
+      if (url.includes('/api/materialsTable/docsInProgress')) {
+        pollStep += 1
+        if (pollStep === 1) {
           return new Response(
             JSON.stringify({
               documents: [
-                { url: 'https://github.com/user/repo/blob/main/README.md' },
-                { url: 'https://github.com/user/repo/blob/main/docs.md' },
+                {
+                  base_url: 'https://github.com/user/repo',
+                  url: 'https://github.com/user/repo/blob/main/README.md',
+                  readable_filename: 'README.md',
+                },
+                {
+                  base_url: 'https://github.com/user/repo',
+                  url: 'https://github.com/user/repo/blob/main/docs.md',
+                  readable_filename: 'docs.md',
+                },
               ],
             }),
             { status: 200, headers: { 'content-type': 'application/json' } },
           )
         }
-        return new Response(JSON.stringify({}), {
+        return new Response(JSON.stringify({ documents: [] }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         })
-      }) as any,
-    )
+      }
+      if (url.includes('/api/materialsTable/successDocs')) {
+        if (pollStep <= 1) {
+          return new Response(JSON.stringify({ documents: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        return new Response(
+          JSON.stringify({
+            documents: [
+              { url: 'https://github.com/user/repo/blob/main/README.md' },
+              { url: 'https://github.com/user/repo/blob/main/docs.md' },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as any)
 
     const GitHubIngestForm = (await import('../GitHubIngestForm')).default
     render(<Harness Component={GitHubIngestForm} queryClient={queryClient} />)
 
     // Gated poller: no interval while nothing is being ingested.
-    expect(setIntervalSpy).not.toHaveBeenCalledWith(
-      expect.any(Function),
-      3000,
-    )
+    expect(setIntervalSpy).not.toHaveBeenCalled()
 
     await user.click(screen.getByText(/^GitHub$/i))
     expect(

--- a/apps/frontend/src/components/UIUC-Components/__tests__/GitHubIngestForm.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/GitHubIngestForm.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { createTestQueryClient } from '~/test-utils/renderWithProviders'
@@ -31,6 +31,27 @@ vi.mock('@mantine/notifications', () => ({
 
 vi.mock('axios', () => ({ default: { post: vi.fn() } }))
 
+/**
+ * Stateful harness: the gated poller only runs while `uploadFiles` contains
+ * active github entries, so tests must hold real state for the gate to open.
+ */
+function Harness(props: any) {
+  const [files, setFiles] = useState<FileUpload[]>(props.initialFiles ?? [])
+  return (
+    <div>
+      <div data-testid="files">{JSON.stringify(files)}</div>
+      <props.Component
+        project_name="CS101"
+        uploadFiles={files}
+        setUploadFiles={setFiles}
+        queryClient={props.queryClient}
+      />
+    </div>
+  )
+}
+
+const filesJson = () => screen.getByTestId('files').textContent ?? ''
+
 describe('GitHubIngestForm', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -40,11 +61,6 @@ describe('GitHubIngestForm', () => {
     const user = userEvent.setup()
     const queryClient = createTestQueryClient()
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
-
-    let uploads: FileUpload[] = []
-    const setUploadFiles = vi.fn((updater: any) => {
-      uploads = typeof updater === 'function' ? updater(uploads) : updater
-    })
 
     // Avoid the hard-coded 8s wait.
     const nativeSetTimeout = globalThis.setTimeout
@@ -71,67 +87,71 @@ describe('GitHubIngestForm', () => {
     // First poll: docs in progress (creates additional file entries)
     // Second poll: completed docs (marks additional entries complete)
     let pollStep = 0
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: any) => {
-      const url = String(input?.url ?? input)
-      if (url.includes('/api/materialsTable/docsInProgress')) {
-        pollStep += 1
-        if (pollStep === 1) {
-          return new Response(
-            JSON.stringify({
-              documents: [
-                {
-                  base_url: 'https://github.com/user/repo',
-                  url: 'https://github.com/user/repo/blob/main/README.md',
-                  readable_filename: 'README.md',
-                },
-                {
-                  base_url: 'https://github.com/user/repo',
-                  url: 'https://github.com/user/repo/blob/main/docs.md',
-                  readable_filename: 'docs.md',
-                },
-              ],
-            }),
-            { status: 200, headers: { 'content-type': 'application/json' } },
-          )
+    const requestBodies: any[] = []
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (async (input: any, init?: any) => {
+        const url = String(input?.url ?? input)
+        if (url.includes('/api/materialsTable/')) {
+          requestBodies.push(JSON.parse(init?.body ?? '{}'))
         }
-        return new Response(JSON.stringify({ documents: [] }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-      }
-      if (url.includes('/api/materialsTable/successDocs')) {
-        if (pollStep <= 1) {
+        if (url.includes('/api/materialsTable/docsInProgress')) {
+          pollStep += 1
+          if (pollStep === 1) {
+            return new Response(
+              JSON.stringify({
+                documents: [
+                  {
+                    base_url: 'https://github.com/user/repo',
+                    url: 'https://github.com/user/repo/blob/main/README.md',
+                    readable_filename: 'README.md',
+                  },
+                  {
+                    base_url: 'https://github.com/user/repo',
+                    url: 'https://github.com/user/repo/blob/main/docs.md',
+                    readable_filename: 'docs.md',
+                  },
+                ],
+              }),
+              { status: 200, headers: { 'content-type': 'application/json' } },
+            )
+          }
           return new Response(JSON.stringify({ documents: [] }), {
             status: 200,
             headers: { 'content-type': 'application/json' },
           })
         }
-        return new Response(
-          JSON.stringify({
-            documents: [
-              { url: 'https://github.com/user/repo/blob/main/README.md' },
-              { url: 'https://github.com/user/repo/blob/main/docs.md' },
-            ],
-          }),
-          { status: 200, headers: { 'content-type': 'application/json' } },
-        )
-      }
-      return new Response(JSON.stringify({}), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      })
-    })
-
-    const GitHubIngestForm = (await import('../GitHubIngestForm')).default
-    render(
-      <GitHubIngestForm
-        project_name="CS101"
-        setUploadFiles={setUploadFiles as any}
-        queryClient={queryClient}
-      />,
+        if (url.includes('/api/materialsTable/successDocs')) {
+          if (pollStep <= 1) {
+            return new Response(JSON.stringify({ documents: [] }), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            })
+          }
+          return new Response(
+            JSON.stringify({
+              documents: [
+                { url: 'https://github.com/user/repo/blob/main/README.md' },
+                { url: 'https://github.com/user/repo/blob/main/docs.md' },
+              ],
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          )
+        }
+        return new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }) as any,
     )
 
-    await waitFor(() => expect(setIntervalSpy).toHaveBeenCalled())
+    const GitHubIngestForm = (await import('../GitHubIngestForm')).default
+    render(<Harness Component={GitHubIngestForm} queryClient={queryClient} />)
+
+    // Gated poller: no interval while nothing is being ingested.
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(
+      expect.any(Function),
+      3000,
+    )
 
     await user.click(screen.getByText(/^GitHub$/i))
     expect(
@@ -151,8 +171,15 @@ describe('GitHubIngestForm', () => {
     await user.click(ingestButton)
     await waitFor(() => expect(axios.post).toHaveBeenCalled())
 
-    if (intervalCallback) await intervalCallback()
-    if (intervalCallback) await intervalCallback()
+    // The gate opens once the base entry is tracked.
+    await waitFor(() => expect(intervalCallback).toBeDefined())
+
+    await act(async () => {
+      if (intervalCallback) await intervalCallback()
+    })
+    await act(async () => {
+      if (intervalCallback) await intervalCallback()
+    })
 
     await waitFor(() =>
       expect(invalidateQueries).toHaveBeenCalledWith({
@@ -160,18 +187,22 @@ describe('GitHubIngestForm', () => {
       }),
     )
 
+    // Every status request filters on the tracked repo (base) URL.
+    expect(requestBodies.length).toBeGreaterThan(0)
+    for (const body of requestBodies) {
+      expect(body).toEqual({
+        course_name: 'CS101',
+        base_urls: ['https://github.com/user/repo'],
+      })
+    }
+
     // Ensure at least one additional file entry became complete.
-    expect(uploads.some((u) => u.status === 'complete')).toBe(true)
+    expect(filesJson()).toContain('"status":"complete"')
   })
 
   it('shows an error toast and marks the upload errored when scraping fails', async () => {
     const user = userEvent.setup()
     const queryClient = createTestQueryClient()
-
-    let uploads: FileUpload[] = []
-    const setUploadFiles = vi.fn((updater: any) => {
-      uploads = typeof updater === 'function' ? updater(uploads) : updater
-    })
 
     const nativeSetTimeout = globalThis.setTimeout
     vi.spyOn(globalThis, 'setTimeout').mockImplementation(((fn: any) => {
@@ -197,13 +228,7 @@ describe('GitHubIngestForm', () => {
     const { notifications } = await import('@mantine/notifications')
     const GitHubIngestForm = (await import('../GitHubIngestForm')).default
 
-    render(
-      <GitHubIngestForm
-        project_name="CS101"
-        setUploadFiles={setUploadFiles as any}
-        queryClient={queryClient}
-      />,
-    )
+    render(<Harness Component={GitHubIngestForm} queryClient={queryClient} />)
 
     await user.click(screen.getByText(/^GitHub$/i))
     expect(
@@ -219,6 +244,6 @@ describe('GitHubIngestForm', () => {
     await user.click(ingestButton)
 
     await waitFor(() => expect((notifications as any).show).toHaveBeenCalled())
-    expect(uploads.some((u) => u.status === 'error')).toBe(true)
+    await waitFor(() => expect(filesJson()).toContain('"status":"error"'))
   })
 })

--- a/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
@@ -1131,6 +1131,57 @@ describe('LargeDropzone', () => {
     expect(setUploadFiles).not.toHaveBeenCalled()
   })
 
+  it('keeps files added while a tick was in flight', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    // Real state, so the tick's updater runs against a list that changed
+    // after the request was sent.
+    let committed: FileUpload[] = [activeDocument('early.pdf', 'ingesting')]
+    const setUploadFiles = vi.fn((updater: any) => {
+      committed = typeof updater === 'function' ? updater(committed) : updater
+    })
+    const getIntervalCb = mockTimers()
+
+    let releaseRequests: (() => void) | undefined
+    const pending = new Promise<void>((resolve) => {
+      releaseRequests = resolve
+    })
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: any) => {
+      await pending
+      const url = String(input?.url ?? input)
+      return new Response(
+        JSON.stringify({
+          documents: url.includes('successDocs')
+            ? [{ readable_filename: 'early.pdf' }]
+            : [],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    }) as any)
+
+    render(
+      <LargeDropzone
+        {...defaultProps({ uploadFiles: committed, setUploadFiles })}
+      />,
+    )
+
+    const intervalCallback = getIntervalCb()
+    expect(intervalCallback).toBeDefined()
+    const tick = intervalCallback ? intervalCallback() : Promise.resolve()
+
+    // A second drop lands before the status response comes back.
+    committed = [...committed, activeDocument('late.pdf')]
+
+    releaseRequests?.()
+    await tick
+
+    // The tick's result is applied without discarding the newer entry.
+    expect(committed.map((file) => [file.name, file.status])).toEqual([
+      ['early.pdf', 'complete'],
+      ['late.pdf', 'uploading'],
+    ])
+  })
+
   it('discards a tick that was still in flight when the gate closed', async () => {
     const { default: LargeDropzone } = await import('../LargeDropzone')
 

--- a/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
@@ -142,11 +142,17 @@ function defaultProps(overrides: Record<string, any> = {}) {
     isDisabled: false,
     courseMetadata: { course_owner: 'me@example.com' } as any,
     is_new_course: false,
-    redirect_to_gpt_4: true,
+    uploadFiles: [] as FileUpload[],
     setUploadFiles: vi.fn() as any,
+    queryClient: { invalidateQueries: vi.fn() } as any,
     auth: { isAuthenticated: true } as any,
     ...overrides,
   }
+}
+
+/** An active document upload that arms the gated poller. */
+function activeDocument(name: string, status: FileUpload['status'] = 'uploading') {
+  return { name, status, type: 'document' as const }
 }
 
 describe('LargeDropzone', () => {
@@ -231,6 +237,7 @@ describe('LargeDropzone', () => {
       <LargeDropzone
         {...defaultProps({
           is_new_course: true,
+          uploadFiles: [activeDocument('My-File.pdf')],
           setUploadFiles,
         })}
       />,
@@ -444,7 +451,6 @@ describe('LargeDropzone', () => {
       <LargeDropzone
         {...defaultProps({
           is_new_course: false,
-          redirect_to_gpt_4: true,
         })}
       />,
     )
@@ -543,7 +549,14 @@ describe('LargeDropzone', () => {
       }),
     )
 
-    render(<LargeDropzone {...defaultProps({ setUploadFiles })} />)
+    render(
+      <LargeDropzone
+        {...defaultProps({
+          uploadFiles: [activeDocument('report.pdf')],
+          setUploadFiles,
+        })}
+      />,
+    )
 
     // Simulate having a file in uploading state
     uploads = [{ name: 'report.pdf', status: 'uploading', type: 'document' }]
@@ -585,7 +598,14 @@ describe('LargeDropzone', () => {
       }),
     )
 
-    render(<LargeDropzone {...defaultProps({ setUploadFiles })} />)
+    render(
+      <LargeDropzone
+        {...defaultProps({
+          uploadFiles: [activeDocument('quick.pdf')],
+          setUploadFiles,
+        })}
+      />,
+    )
 
     const intervalCallback = getIntervalCb()
     if (intervalCallback) await intervalCallback()
@@ -618,7 +638,14 @@ describe('LargeDropzone', () => {
       }),
     )
 
-    render(<LargeDropzone {...defaultProps({ setUploadFiles })} />)
+    render(
+      <LargeDropzone
+        {...defaultProps({
+          uploadFiles: [activeDocument('done.pdf', 'ingesting')],
+          setUploadFiles,
+        })}
+      />,
+    )
 
     const intervalCallback = getIntervalCb()
     if (intervalCallback) await intervalCallback()
@@ -649,7 +676,14 @@ describe('LargeDropzone', () => {
       }),
     )
 
-    render(<LargeDropzone {...defaultProps({ setUploadFiles })} />)
+    render(
+      <LargeDropzone
+        {...defaultProps({
+          uploadFiles: [activeDocument('failed.pdf', 'ingesting')],
+          setUploadFiles,
+        })}
+      />,
+    )
 
     const intervalCallback = getIntervalCb()
     if (intervalCallback) await intervalCallback()
@@ -679,7 +713,14 @@ describe('LargeDropzone', () => {
       }),
     )
 
-    render(<LargeDropzone {...defaultProps({ setUploadFiles })} />)
+    render(
+      <LargeDropzone
+        {...defaultProps({
+          uploadFiles: [activeDocument('other.pdf')],
+          setUploadFiles,
+        })}
+      />,
+    )
 
     const intervalCallback = getIntervalCb()
     if (intervalCallback) await intervalCallback()
@@ -716,7 +757,14 @@ describe('LargeDropzone', () => {
       }),
     )
 
-    render(<LargeDropzone {...defaultProps({ setUploadFiles })} />)
+    render(
+      <LargeDropzone
+        {...defaultProps({
+          uploadFiles: [activeDocument('still-going.pdf', 'ingesting')],
+          setUploadFiles,
+        })}
+      />,
+    )
 
     const intervalCallback = getIntervalCb()
     if (intervalCallback) await intervalCallback()
@@ -748,7 +796,14 @@ describe('LargeDropzone', () => {
       }),
     )
 
-    render(<LargeDropzone {...defaultProps({ setUploadFiles })} />)
+    render(
+      <LargeDropzone
+        {...defaultProps({
+          uploadFiles: [activeDocument('pending.pdf')],
+          setUploadFiles,
+        })}
+      />,
+    )
 
     const intervalCallback = getIntervalCb()
     if (intervalCallback) await intervalCallback()
@@ -764,6 +819,250 @@ describe('LargeDropzone', () => {
       // Should stay 'uploading' because it's not visible in either API yet
       expect(result[0].status).toBe('uploading')
     }
+  })
+
+  // -----------------------------------------------------------------------
+  // Gated polling
+  // -----------------------------------------------------------------------
+
+  it('does not arm the polling interval when no document uploads are active', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    const getIntervalCb = mockTimers()
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(buildFetchMock({}))
+
+    render(
+      <LargeDropzone
+        {...defaultProps({
+          uploadFiles: [
+            { name: 'done.pdf', status: 'complete', type: 'document' },
+            { name: 'https://a.com', status: 'uploading', type: 'webscrape' },
+          ],
+        })}
+      />,
+    )
+
+    expect(getIntervalCb()).toBeUndefined()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('POSTs the tracked filenames to both status endpoints', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    const getIntervalCb = mockTimers()
+    const calls: { url: string; body: any }[] = []
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (async (input: any, init?: any) => {
+        const url = String(input?.url ?? input)
+        if (url.includes('/api/materialsTable/')) {
+          calls.push({ url, body: JSON.parse(init?.body ?? '{}') })
+        }
+        return new Response(JSON.stringify({ documents: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }) as any,
+    )
+
+    render(
+      <LargeDropzone
+        {...defaultProps({ uploadFiles: [activeDocument('report.pdf')] })}
+      />,
+    )
+
+    const intervalCallback = getIntervalCb()
+    expect(intervalCallback).toBeDefined()
+    if (intervalCallback) await intervalCallback()
+
+    expect(calls).toHaveLength(2)
+    expect(calls.map((c) => c.url).sort()).toEqual([
+      '/api/materialsTable/docsInProgress',
+      '/api/materialsTable/successDocs',
+    ])
+    for (const call of calls) {
+      expect(call.body).toEqual({
+        course_name: 'CS101',
+        filenames: ['report.pdf'],
+      })
+    }
+  })
+
+  it('skips the status update when a status endpoint fails', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    const setUploadFiles = vi.fn()
+    const getIntervalCb = mockTimers()
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (async (input: any) => {
+        const url = String(input?.url ?? input)
+        if (url.includes('/api/materialsTable/successDocs')) {
+          return new Response(JSON.stringify({ error: 'boom' }), {
+            status: 500,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        return new Response(JSON.stringify({ documents: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }) as any,
+    )
+
+    render(
+      <LargeDropzone
+        {...defaultProps({
+          uploadFiles: [activeDocument('flaky.pdf', 'ingesting')],
+          setUploadFiles,
+        })}
+      />,
+    )
+
+    const intervalCallback = getIntervalCb()
+    if (intervalCallback) await intervalCallback()
+
+    // The file must NOT be flipped to 'error' just because a request failed.
+    expect(setUploadFiles).not.toHaveBeenCalled()
+  })
+
+  it('invalidates documents on complete-transition and both keys on gate close', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    const invalidateQueries = vi.fn()
+    const getIntervalCb = mockTimers()
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      buildFetchMock({
+        docsInProgress: () => ({ documents: [] }),
+        successDocs: () => ({
+          documents: [{ readable_filename: 'done.pdf' }],
+        }),
+      }),
+    )
+
+    const props = defaultProps({
+      uploadFiles: [activeDocument('done.pdf', 'ingesting')],
+      queryClient: { invalidateQueries } as any,
+    })
+    const { rerender } = render(<LargeDropzone {...props} />)
+
+    const intervalCallback = getIntervalCb()
+    if (intervalCallback) await intervalCallback()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['documents', 'CS101'],
+    })
+
+    invalidateQueries.mockClear()
+
+    // Gate closes: the tracked file went terminal.
+    rerender(
+      <LargeDropzone
+        {...props}
+        uploadFiles={[
+          { name: 'done.pdf', status: 'complete', type: 'document' },
+        ]}
+      />,
+    )
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['documents', 'CS101'],
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['failedDocuments', 'CS101'],
+    })
+  })
+
+  it('chunks filter POSTs above the server cap and merges results', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    let uploads: FileUpload[] = []
+    const setUploadFiles = vi.fn((updater: any) => {
+      uploads = typeof updater === 'function' ? updater(uploads) : updater
+    })
+    const getIntervalCb = mockTimers()
+
+    const manyFiles: FileUpload[] = Array.from({ length: 1001 }, (_, i) =>
+      activeDocument(`doc-${i}.pdf`, 'ingesting'),
+    )
+    uploads = manyFiles
+
+    const bodies: any[] = []
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (async (input: any, init?: any) => {
+        const url = String(input?.url ?? input)
+        const body = JSON.parse(init?.body ?? '{}')
+        bodies.push({ url, count: body.filenames?.length ?? 0 })
+        // Every tracked file is completed.
+        return new Response(
+          JSON.stringify({
+            documents: url.includes('successDocs')
+              ? body.filenames.map((name: string) => ({
+                  readable_filename: name,
+                }))
+              : [],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }) as any,
+    )
+
+    render(
+      <LargeDropzone
+        {...defaultProps({ uploadFiles: manyFiles, setUploadFiles })}
+      />,
+    )
+
+    const intervalCallback = getIntervalCb()
+    if (intervalCallback) await intervalCallback()
+
+    // 2 chunks (1000 + 1) × 2 endpoints
+    expect(bodies).toHaveLength(4)
+    expect(bodies.map((b) => b.count).sort()).toEqual([1, 1, 1000, 1000])
+    // Merged results complete every file, including the one in the second chunk.
+    expect(uploads.every((f) => f.status === 'complete')).toBe(true)
+  })
+
+  it('skips the whole tick when one chunk fails', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    const setUploadFiles = vi.fn()
+    const getIntervalCb = mockTimers()
+
+    const manyFiles: FileUpload[] = Array.from({ length: 1001 }, (_, i) =>
+      activeDocument(`doc-${i}.pdf`, 'ingesting'),
+    )
+
+    let requestCount = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (async () => {
+        requestCount++
+        if (requestCount > 2) {
+          return new Response(JSON.stringify({ error: 'boom' }), {
+            status: 500,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        return new Response(JSON.stringify({ documents: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }) as any,
+    )
+
+    render(
+      <LargeDropzone
+        {...defaultProps({ uploadFiles: manyFiles, setUploadFiles })}
+      />,
+    )
+
+    const intervalCallback = getIntervalCb()
+    if (intervalCallback) await intervalCallback()
+
+    // No partial merge: statuses untouched when any chunk request failed.
+    expect(setUploadFiles).not.toHaveBeenCalled()
   })
 
   // -----------------------------------------------------------------------

--- a/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
@@ -919,7 +919,7 @@ describe('LargeDropzone', () => {
     expect(setUploadFiles).not.toHaveBeenCalled()
   })
 
-  it('invalidates documents on complete-transition and both keys on gate close', async () => {
+  it('invalidates documents once per batch, not again on gate close', async () => {
     const { default: LargeDropzone } = await import('../LargeDropzone')
 
     const invalidateQueries = vi.fn()
@@ -955,6 +955,39 @@ describe('LargeDropzone', () => {
         {...props}
         uploadFiles={[
           { name: 'done.pdf', status: 'complete', type: 'document' },
+        ]}
+      />,
+    )
+
+    // The tick above already refreshed the table, so re-issuing it here would
+    // only cancel that request and start another.
+    expect(invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ['documents', 'CS101'],
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['failedDocuments', 'CS101'],
+    })
+  })
+
+  it('still refreshes the table on gate close when no tick did', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    const invalidateQueries = vi.fn()
+    mockTimers()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(buildFetchMock({}))
+
+    const props = defaultProps({
+      uploadFiles: [activeDocument('doomed.pdf')],
+      queryClient: { invalidateQueries } as any,
+    })
+    const { rerender } = render(<LargeDropzone {...props} />)
+
+    // Upload fails outside the poller, so no tick ever saw a transition.
+    rerender(
+      <LargeDropzone
+        {...props}
+        uploadFiles={[
+          { name: 'doomed.pdf', status: 'error', type: 'document' },
         ]}
       />,
     )

--- a/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
@@ -215,8 +215,7 @@ describe('LargeDropzone', () => {
     const { callSetCourseMetadata } = await import('~/utils/apiUtils')
 
     const push = vi.fn(async () => {})
-    const reload = vi.fn()
-    globalThis.__TEST_ROUTER__ = { asPath: '/CS101/dashboard', push, reload }
+    globalThis.__TEST_ROUTER__ = { asPath: '/CS101/dashboard', push }
 
     let uploads: FileUpload[] = []
     const setUploadFiles = vi.fn((updater: any) => {
@@ -444,8 +443,7 @@ describe('LargeDropzone', () => {
     const { default: LargeDropzone } = await import('../LargeDropzone')
 
     const push = vi.fn(async () => {})
-    const reload = vi.fn(async () => {})
-    globalThis.__TEST_ROUTER__ = { push, reload }
+    globalThis.__TEST_ROUTER__ = { push }
 
     mockTimers()
     vi.spyOn(globalThis, 'fetch').mockImplementation(buildFetchMock({}))
@@ -1368,8 +1366,7 @@ describe('LargeDropzone', () => {
     const { callSetCourseMetadata } = await import('~/utils/apiUtils')
 
     const push = vi.fn(async () => {})
-    const reload = vi.fn()
-    globalThis.__TEST_ROUTER__ = { push, reload }
+    globalThis.__TEST_ROUTER__ = { push }
 
     mockTimers()
     vi.spyOn(globalThis, 'fetch').mockImplementation(buildFetchMock({}))

--- a/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
@@ -1131,6 +1131,84 @@ describe('LargeDropzone', () => {
     expect(setUploadFiles).not.toHaveBeenCalled()
   })
 
+  it('does not read successDocs until docsInProgress has answered', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    const getIntervalCb = mockTimers()
+    // Ingest writes the document row and only then deletes the in-progress
+    // row. If both reads are in flight at once, successDocs can observe the
+    // database before the row is written while docsInProgress observes it
+    // after the delete — the doc is then missing from both and a healthy
+    // ingest gets reported as failed.
+    let inProgressAnswered = false
+    let readConcurrently = false
+    let releaseInProgress: (() => void) | undefined
+    const inProgressGate = new Promise<void>((resolve) => {
+      releaseInProgress = resolve
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: any) => {
+      const url = String(input?.url ?? input)
+      if (url.includes('/api/materialsTable/docsInProgress')) {
+        await inProgressGate
+        inProgressAnswered = true
+      }
+      if (url.includes('/api/materialsTable/successDocs')) {
+        if (!inProgressAnswered) readConcurrently = true
+      }
+      return new Response(JSON.stringify({ documents: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as any)
+
+    render(
+      <LargeDropzone
+        {...defaultProps({ uploadFiles: [activeDocument('a.pdf')] })}
+      />,
+    )
+
+    const intervalCallback = getIntervalCb()
+    expect(intervalCallback).toBeDefined()
+    const tick = intervalCallback ? intervalCallback() : Promise.resolve()
+    // Let anything that was going to run concurrently do so.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    releaseInProgress?.()
+    await tick
+
+    expect(readConcurrently).toBe(false)
+    expect(inProgressAnswered).toBe(true)
+  })
+
+  it('invalidates only failedDocuments when a tick just errors', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    const invalidateQueries = vi.fn()
+    const getIntervalCb = mockTimers()
+
+    // Absent from both lists: the ingest failed.
+    vi.spyOn(globalThis, 'fetch').mockImplementation(buildFetchMock({}))
+
+    render(
+      <LargeDropzone
+        {...defaultProps({
+          uploadFiles: [activeDocument('gone.pdf', 'ingesting')],
+          queryClient: { invalidateQueries } as any,
+        })}
+      />,
+    )
+
+    const intervalCallback = getIntervalCb()
+    if (intervalCallback) await intervalCallback()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['failedDocuments', 'CS101'],
+    })
+    expect(invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ['documents', 'CS101'],
+    })
+  })
+
   it('keeps files added while a tick was in flight', async () => {
     const { default: LargeDropzone } = await import('../LargeDropzone')
 

--- a/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
@@ -919,7 +919,7 @@ describe('LargeDropzone', () => {
     expect(setUploadFiles).not.toHaveBeenCalled()
   })
 
-  it('invalidates documents once per batch, not again on gate close', async () => {
+  it('invalidates documents on complete-transition and both keys on gate close', async () => {
     const { default: LargeDropzone } = await import('../LargeDropzone')
 
     const invalidateQueries = vi.fn()
@@ -959,13 +959,53 @@ describe('LargeDropzone', () => {
       />,
     )
 
-    // The tick above already refreshed the table, so re-issuing it here would
-    // only cancel that request and start another.
-    expect(invalidateQueries).not.toHaveBeenCalledWith({
+    // Rows can land just after a file goes terminal, so the close always
+    // refreshes — one possibly-redundant refetch per batch.
+    expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: ['documents', 'CS101'],
     })
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: ['failedDocuments', 'CS101'],
+    })
+  })
+
+  it('refreshes again when a second batch starts and finishes', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    const invalidateQueries = vi.fn()
+    mockTimers()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(buildFetchMock({}))
+
+    const props = defaultProps({
+      uploadFiles: [activeDocument('first.pdf')],
+      queryClient: { invalidateQueries } as any,
+    })
+    const done = (name: string) => ({
+      name,
+      status: 'complete' as const,
+      type: 'document' as const,
+    })
+    const { rerender } = render(<LargeDropzone {...props} />)
+
+    rerender(<LargeDropzone {...props} uploadFiles={[done('first.pdf')]} />)
+    invalidateQueries.mockClear()
+
+    // A second upload starts and finishes: its rows must be picked up too.
+    rerender(
+      <LargeDropzone
+        {...props}
+        uploadFiles={[done('first.pdf'), activeDocument('second.pdf')]}
+      />,
+    )
+    rerender(
+      <LargeDropzone
+        {...props}
+        uploadFiles={[done('first.pdf'), done('second.pdf')]}
+      />,
+    )
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['documents', 'CS101'],
     })
   })
 

--- a/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
@@ -151,7 +151,10 @@ function defaultProps(overrides: Record<string, any> = {}) {
 }
 
 /** An active document upload that arms the gated poller. */
-function activeDocument(name: string, status: FileUpload['status'] = 'uploading') {
+function activeDocument(
+  name: string,
+  status: FileUpload['status'] = 'uploading',
+) {
   return { name, status, type: 'document' as const }
 }
 
@@ -436,7 +439,7 @@ describe('LargeDropzone', () => {
   // Non-new-course redirects
   // -----------------------------------------------------------------------
 
-  it('redirects to chat when redirect_to_gpt_4 is true and not a new course', async () => {
+  it('does not navigate away after uploading to an existing course', async () => {
     const user = userEvent.setup()
     const { default: LargeDropzone } = await import('../LargeDropzone')
 
@@ -716,7 +719,9 @@ describe('LargeDropzone', () => {
     render(
       <LargeDropzone
         {...defaultProps({
-          uploadFiles: [activeDocument('other.pdf')],
+          // A document completing makes the tick apply an update, so the
+          // webscrape entry below is exercised rather than skipped.
+          uploadFiles: [activeDocument('other.pdf', 'ingesting')],
           setUploadFiles,
         })}
       />,
@@ -736,6 +741,7 @@ describe('LargeDropzone', () => {
         type: 'webscrape',
       }
       const result = updater[0]([webscrapeFile])
+      expect(result[0]).toBe(webscrapeFile)
       expect(result[0].status).toBe('uploading')
       expect(result[0].type).toBe('webscrape')
     }
@@ -767,19 +773,12 @@ describe('LargeDropzone', () => {
     )
 
     const intervalCallback = getIntervalCb()
+    expect(intervalCallback).toBeDefined()
     if (intervalCallback) await intervalCallback()
 
-    const updater = setUploadFiles.mock.calls.find(
-      (call: any[]) => typeof call[0] === 'function',
-    )
-    expect(updater).toBeDefined()
-    if (updater) {
-      const result = updater[0]([
-        { name: 'still-going.pdf', status: 'ingesting', type: 'document' },
-      ])
-      // Should remain 'ingesting' since it's still in docsInProgress
-      expect(result[0].status).toBe('ingesting')
-    }
+    // Still in docsInProgress means nothing changed, so the tick must not
+    // touch state at all (which is what keeps the file 'ingesting').
+    expect(setUploadFiles).not.toHaveBeenCalled()
   })
 
   it('leaves uploading file unchanged when not in docsInProgress or successDocs yet', async () => {
@@ -806,19 +805,12 @@ describe('LargeDropzone', () => {
     )
 
     const intervalCallback = getIntervalCb()
+    expect(intervalCallback).toBeDefined()
     if (intervalCallback) await intervalCallback()
 
-    const updater = setUploadFiles.mock.calls.find(
-      (call: any[]) => typeof call[0] === 'function',
-    )
-    expect(updater).toBeDefined()
-    if (updater) {
-      const result = updater[0]([
-        { name: 'pending.pdf', status: 'uploading', type: 'document' },
-      ])
-      // Should stay 'uploading' because it's not visible in either API yet
-      expect(result[0].status).toBe('uploading')
-    }
+    // Not visible in either API yet, so the file stays 'uploading' and the
+    // tick makes no state update.
+    expect(setUploadFiles).not.toHaveBeenCalled()
   })
 
   // -----------------------------------------------------------------------
@@ -853,18 +845,19 @@ describe('LargeDropzone', () => {
 
     const getIntervalCb = mockTimers()
     const calls: { url: string; body: any }[] = []
-    vi.spyOn(globalThis, 'fetch').mockImplementation(
-      (async (input: any, init?: any) => {
-        const url = String(input?.url ?? input)
-        if (url.includes('/api/materialsTable/')) {
-          calls.push({ url, body: JSON.parse(init?.body ?? '{}') })
-        }
-        return new Response(JSON.stringify({ documents: [] }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-      }) as any,
-    )
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (
+      input: any,
+      init?: any,
+    ) => {
+      const url = String(input?.url ?? input)
+      if (url.includes('/api/materialsTable/')) {
+        calls.push({ url, body: JSON.parse(init?.body ?? '{}') })
+      }
+      return new Response(JSON.stringify({ documents: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as any)
 
     render(
       <LargeDropzone
@@ -895,21 +888,19 @@ describe('LargeDropzone', () => {
     const setUploadFiles = vi.fn()
     const getIntervalCb = mockTimers()
 
-    vi.spyOn(globalThis, 'fetch').mockImplementation(
-      (async (input: any) => {
-        const url = String(input?.url ?? input)
-        if (url.includes('/api/materialsTable/successDocs')) {
-          return new Response(JSON.stringify({ error: 'boom' }), {
-            status: 500,
-            headers: { 'content-type': 'application/json' },
-          })
-        }
-        return new Response(JSON.stringify({ documents: [] }), {
-          status: 200,
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: any) => {
+      const url = String(input?.url ?? input)
+      if (url.includes('/api/materialsTable/successDocs')) {
+        return new Response(JSON.stringify({ error: 'boom' }), {
+          status: 500,
           headers: { 'content-type': 'application/json' },
         })
-      }) as any,
-    )
+      }
+      return new Response(JSON.stringify({ documents: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as any)
 
     render(
       <LargeDropzone
@@ -921,6 +912,7 @@ describe('LargeDropzone', () => {
     )
 
     const intervalCallback = getIntervalCb()
+    expect(intervalCallback).toBeDefined()
     if (intervalCallback) await intervalCallback()
 
     // The file must NOT be flipped to 'error' just because a request failed.
@@ -990,24 +982,25 @@ describe('LargeDropzone', () => {
     uploads = manyFiles
 
     const bodies: any[] = []
-    vi.spyOn(globalThis, 'fetch').mockImplementation(
-      (async (input: any, init?: any) => {
-        const url = String(input?.url ?? input)
-        const body = JSON.parse(init?.body ?? '{}')
-        bodies.push({ url, count: body.filenames?.length ?? 0 })
-        // Every tracked file is completed.
-        return new Response(
-          JSON.stringify({
-            documents: url.includes('successDocs')
-              ? body.filenames.map((name: string) => ({
-                  readable_filename: name,
-                }))
-              : [],
-          }),
-          { status: 200, headers: { 'content-type': 'application/json' } },
-        )
-      }) as any,
-    )
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (
+      input: any,
+      init?: any,
+    ) => {
+      const url = String(input?.url ?? input)
+      const body = JSON.parse(init?.body ?? '{}')
+      bodies.push({ url, count: body.filenames?.length ?? 0 })
+      // Every tracked file is completed.
+      return new Response(
+        JSON.stringify({
+          documents: url.includes('successDocs')
+            ? body.filenames.map((name: string) => ({
+                readable_filename: name,
+              }))
+            : [],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    }) as any)
 
     render(
       <LargeDropzone
@@ -1036,21 +1029,19 @@ describe('LargeDropzone', () => {
     )
 
     let requestCount = 0
-    vi.spyOn(globalThis, 'fetch').mockImplementation(
-      (async () => {
-        requestCount++
-        if (requestCount > 2) {
-          return new Response(JSON.stringify({ error: 'boom' }), {
-            status: 500,
-            headers: { 'content-type': 'application/json' },
-          })
-        }
-        return new Response(JSON.stringify({ documents: [] }), {
-          status: 200,
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      requestCount++
+      if (requestCount > 2) {
+        return new Response(JSON.stringify({ error: 'boom' }), {
+          status: 500,
           headers: { 'content-type': 'application/json' },
         })
-      }) as any,
-    )
+      }
+      return new Response(JSON.stringify({ documents: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as any)
 
     render(
       <LargeDropzone
@@ -1059,9 +1050,69 @@ describe('LargeDropzone', () => {
     )
 
     const intervalCallback = getIntervalCb()
+    expect(intervalCallback).toBeDefined()
     if (intervalCallback) await intervalCallback()
 
     // No partial merge: statuses untouched when any chunk request failed.
+    expect(requestCount).toBeGreaterThan(2)
+    expect(setUploadFiles).not.toHaveBeenCalled()
+  })
+
+  it('discards a tick that was still in flight when the gate closed', async () => {
+    const { default: LargeDropzone } = await import('../LargeDropzone')
+
+    const setUploadFiles = vi.fn()
+    const getIntervalCb = mockTimers()
+
+    // Hold the status requests open so the tick for 'first.pdf' is still
+    // pending while the queue drains and a different upload starts.
+    let releaseRequests: (() => void) | undefined
+    const pending = new Promise<void>((resolve) => {
+      releaseRequests = resolve
+    })
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      await pending
+      return new Response(JSON.stringify({ documents: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as any)
+
+    const props = defaultProps({
+      uploadFiles: [activeDocument('first.pdf', 'ingesting')],
+      setUploadFiles,
+    })
+    const { rerender } = render(<LargeDropzone {...props} />)
+
+    const staleTickCallback = getIntervalCb()
+    expect(staleTickCallback).toBeDefined()
+    const staleTick = staleTickCallback
+      ? staleTickCallback()
+      : Promise.resolve()
+
+    // Queue drains (gate closes), then a NEW upload starts (gate reopens).
+    rerender(
+      <LargeDropzone
+        {...props}
+        uploadFiles={[{ name: 'first.pdf', status: 'error', type: 'document' }]}
+      />,
+    )
+    rerender(
+      <LargeDropzone
+        {...props}
+        uploadFiles={[
+          { name: 'first.pdf', status: 'error', type: 'document' },
+          activeDocument('second.pdf', 'ingesting'),
+        ]}
+      />,
+    )
+
+    releaseRequests?.()
+    await staleTick
+
+    // The stale response only ever described 'first.pdf'. Applying it would
+    // mark the healthy 'second.pdf' ingest as failed, since it is necessarily
+    // absent from those results.
     expect(setUploadFiles).not.toHaveBeenCalled()
   })
 

--- a/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/LargeDropzone.test.tsx
@@ -824,6 +824,7 @@ describe('LargeDropzone', () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockImplementation(buildFetchMock({}))
+    const invalidateQueries = vi.fn()
 
     render(
       <LargeDropzone
@@ -832,12 +833,15 @@ describe('LargeDropzone', () => {
             { name: 'done.pdf', status: 'complete', type: 'document' },
             { name: 'https://a.com', status: 'uploading', type: 'webscrape' },
           ],
+          queryClient: { invalidateQueries } as any,
         })}
       />,
     )
 
     expect(getIntervalCb()).toBeUndefined()
     expect(fetchSpy).not.toHaveBeenCalled()
+    // An idle dashboard must also not refetch the documents table on mount.
+    expect(invalidateQueries).not.toHaveBeenCalled()
   })
 
   it('POSTs the tracked filenames to both status endpoints', async () => {

--- a/apps/frontend/src/components/UIUC-Components/__tests__/ProjectFilesTable.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/ProjectFilesTable.test.tsx
@@ -390,6 +390,98 @@ describe('ProjectFilesTable', () => {
     else delete (HTMLElement.prototype as any).clientHeight
   }, 20_000)
 
+  it('refreshes both queries via the refresh button and restarts the 5-minute timer', async () => {
+    const user = userEvent.setup()
+
+    // Capture the 5-minute auto-refresh interval while leaving all other
+    // timers (waitFor polling, userEvent) on the native implementations.
+    const armedCallbacks: Array<() => void> = []
+    const nativeSetInterval = globalThis.setInterval
+    const nativeClearInterval = globalThis.clearInterval
+    let clearedRefreshTimers = 0
+    vi.spyOn(globalThis, 'setInterval').mockImplementation(((
+      cb: any,
+      delay?: any,
+      ...args: any[]
+    ) => {
+      if (delay === 5 * 60_000) {
+        armedCallbacks.push(cb)
+        return 987_654 as any
+      }
+      return nativeSetInterval(cb, delay, ...args)
+    }) as any)
+    vi.spyOn(globalThis, 'clearInterval').mockImplementation(((id: any) => {
+      if (id === 987_654) {
+        clearedRefreshTimers += 1
+        return
+      }
+      return nativeClearInterval(id)
+    }) as any)
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const countCalls = (pattern: RegExp) =>
+      fetchSpy.mock.calls.filter(([url]) => pattern.test(String(url))).length
+
+    server.use(
+      http.get('*/api/materialsTable/fetchProjectMaterials*', async () => {
+        return HttpResponse.json({ final_docs: [], total_count: 0 })
+      }),
+      http.get('*/api/materialsTable/fetchFailedDocuments*', async () => {
+        return HttpResponse.json({
+          final_docs: [],
+          total_count: 0,
+          recent_fail_count: 0,
+        })
+      }),
+    )
+
+    globalThis.__TEST_ROUTER__ = { asPath: '/CS101/dashboard' }
+    const { ProjectFilesTable } = await import('../ProjectFilesTable')
+    renderWithProviders(
+      <ProjectFilesTable
+        course_name="CS101"
+        tabValue="success"
+        onTabChange={vi.fn()}
+        setFailedCount={vi.fn()}
+        failedCount={0}
+      />,
+      { homeContext: { dispatch: vi.fn() } },
+    )
+
+    await screen.findByText(/Success/i)
+    expect(armedCallbacks).toHaveLength(1)
+
+    // Manual refresh refetches both queries…
+    const materialsBefore = countCalls(/fetchProjectMaterials/)
+    const failedBefore = countCalls(/fetchFailedDocuments/)
+    await user.click(
+      screen.getByRole('button', { name: /refresh documents table/i }),
+    )
+    await waitFor(() => {
+      expect(countCalls(/fetchProjectMaterials/)).toBeGreaterThan(
+        materialsBefore,
+      )
+      expect(countCalls(/fetchFailedDocuments/)).toBeGreaterThan(failedBefore)
+    })
+
+    // …and restarts the countdown (old interval cleared, new one armed).
+    await waitFor(() => expect(armedCallbacks).toHaveLength(2))
+    expect(clearedRefreshTimers).toBe(1)
+
+    // Firing the timer refetches both queries too.
+    const materialsBeforeTick = countCalls(/fetchProjectMaterials/)
+    const failedBeforeTick = countCalls(/fetchFailedDocuments/)
+    armedCallbacks[1]!()
+    await waitFor(() => {
+      expect(countCalls(/fetchProjectMaterials/)).toBeGreaterThan(
+        materialsBeforeTick,
+      )
+      expect(countCalls(/fetchFailedDocuments/)).toBeGreaterThan(
+        failedBeforeTick,
+      )
+    })
+  }, 20_000)
+
   it('renders an error-state table when document fetch fails', async () => {
     const { showNotification } = await import('@mantine/notifications')
 

--- a/apps/frontend/src/components/UIUC-Components/__tests__/ProjectFilesTable.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/ProjectFilesTable.test.tsx
@@ -64,14 +64,14 @@ vi.mock('mantine-datatable', () => ({
           ))}
         </div>
         <div>
-          {records.length === 0 ? props.noRecordsIcon ?? null : null}
+          {records.length === 0 ? (props.noRecordsIcon ?? null) : null}
           {records.map((record: any, index: number) => (
             <div key={record.id ?? record.s3_path ?? record.url ?? index}>
               {columns.map((col: any, cIdx: number) => (
                 <div key={cIdx}>
                   {col.render
                     ? col.render(record, index)
-                    : record[col.accessor] ?? null}
+                    : (record[col.accessor] ?? null)}
                 </div>
               ))}
             </div>

--- a/apps/frontend/src/components/UIUC-Components/__tests__/ProjectFilesTable.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/ProjectFilesTable.test.tsx
@@ -64,14 +64,14 @@ vi.mock('mantine-datatable', () => ({
           ))}
         </div>
         <div>
-          {records.length === 0 ? (props.noRecordsIcon ?? null) : null}
+          {records.length === 0 ? props.noRecordsIcon ?? null : null}
           {records.map((record: any, index: number) => (
             <div key={record.id ?? record.s3_path ?? record.url ?? index}>
               {columns.map((col: any, cIdx: number) => (
                 <div key={cIdx}>
                   {col.render
                     ? col.render(record, index)
-                    : (record[col.accessor] ?? null)}
+                    : record[col.accessor] ?? null}
                 </div>
               ))}
             </div>
@@ -390,33 +390,8 @@ describe('ProjectFilesTable', () => {
     else delete (HTMLElement.prototype as any).clientHeight
   }, 20_000)
 
-  it('refreshes both queries via the refresh button and restarts the 5-minute timer', async () => {
+  it('refreshes both queries when the refresh button is clicked', async () => {
     const user = userEvent.setup()
-
-    // Capture the 5-minute auto-refresh interval while leaving all other
-    // timers (waitFor polling, userEvent) on the native implementations.
-    const armedCallbacks: Array<() => void> = []
-    const nativeSetInterval = globalThis.setInterval
-    const nativeClearInterval = globalThis.clearInterval
-    let clearedRefreshTimers = 0
-    vi.spyOn(globalThis, 'setInterval').mockImplementation(((
-      cb: any,
-      delay?: any,
-      ...args: any[]
-    ) => {
-      if (delay === 5 * 60_000) {
-        armedCallbacks.push(cb)
-        return 987_654 as any
-      }
-      return nativeSetInterval(cb, delay, ...args)
-    }) as any)
-    vi.spyOn(globalThis, 'clearInterval').mockImplementation(((id: any) => {
-      if (id === 987_654) {
-        clearedRefreshTimers += 1
-        return
-      }
-      return nativeClearInterval(id)
-    }) as any)
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
     const countCalls = (pattern: RegExp) =>
@@ -449,9 +424,7 @@ describe('ProjectFilesTable', () => {
     )
 
     await screen.findByText(/Success/i)
-    expect(armedCallbacks).toHaveLength(1)
 
-    // Manual refresh refetches both queries…
     const materialsBefore = countCalls(/fetchProjectMaterials/)
     const failedBefore = countCalls(/fetchFailedDocuments/)
     await user.click(
@@ -462,23 +435,6 @@ describe('ProjectFilesTable', () => {
         materialsBefore,
       )
       expect(countCalls(/fetchFailedDocuments/)).toBeGreaterThan(failedBefore)
-    })
-
-    // …and restarts the countdown (old interval cleared, new one armed).
-    await waitFor(() => expect(armedCallbacks).toHaveLength(2))
-    expect(clearedRefreshTimers).toBe(1)
-
-    // Firing the timer refetches both queries too.
-    const materialsBeforeTick = countCalls(/fetchProjectMaterials/)
-    const failedBeforeTick = countCalls(/fetchFailedDocuments/)
-    armedCallbacks[1]!()
-    await waitFor(() => {
-      expect(countCalls(/fetchProjectMaterials/)).toBeGreaterThan(
-        materialsBeforeTick,
-      )
-      expect(countCalls(/fetchFailedDocuments/)).toBeGreaterThan(
-        failedBeforeTick,
-      )
     })
   }, 20_000)
 

--- a/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
@@ -343,8 +343,10 @@ describe('WebsiteIngestForm', () => {
   })
 
   it('does not invalidate queries on a no-change tick', async () => {
+    // Capture the tick so it can be awaited, rather than racing a waitFor.
+    let tick: (() => Promise<void>) | undefined
     vi.spyOn(globalThis, 'setInterval').mockImplementation(((fn: any) => {
-      fn()
+      tick = fn
       return 0
     }) as any)
 
@@ -369,7 +371,6 @@ describe('WebsiteIngestForm', () => {
     const { default: WebsiteIngestForm } = await import('../WebsiteIngestForm')
     const queryClient = createTestQueryClient()
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
-    const fetchSpy = vi.spyOn(globalThis, 'fetch')
     renderWithProviders(
       <Harness
         Component={WebsiteIngestForm}
@@ -387,14 +388,17 @@ describe('WebsiteIngestForm', () => {
       { homeContext: { dispatch: vi.fn() }, queryClient },
     )
 
-    // Wait until the tick has actually round-tripped both endpoints, so the
-    // assertion can't pass merely because nothing had run yet.
-    await waitFor(() => {
-      const statusCalls = fetchSpy.mock.calls.filter(([url]) =>
+    // Run a full tick, so the assertion can't pass merely because nothing ran.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    expect(tick).toBeDefined()
+    if (tick) await tick()
+
+    // Both endpoints answered — the tick did not bail out early.
+    expect(
+      fetchSpy.mock.calls.filter(([url]) =>
         /materialsTable\/(docsInProgress|successDocs)/.test(String(url)),
-      )
-      expect(statusCalls.length).toBeGreaterThanOrEqual(2)
-    })
+      ),
+    ).toHaveLength(2)
     expect(invalidateSpy).not.toHaveBeenCalled()
   })
 

--- a/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
@@ -308,6 +308,7 @@ describe('WebsiteIngestForm', () => {
     const { default: WebsiteIngestForm } = await import('../WebsiteIngestForm')
     const queryClient = createTestQueryClient()
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
     renderWithProviders(
       <Harness
         Component={WebsiteIngestForm}
@@ -325,8 +326,14 @@ describe('WebsiteIngestForm', () => {
       { homeContext: { dispatch: vi.fn() }, queryClient },
     )
 
-    // Give the async tick a chance to finish.
-    await new Promise((resolve) => globalThis.setTimeout(resolve, 50))
+    // Wait until the tick has actually round-tripped both endpoints, so the
+    // assertion can't pass merely because nothing had run yet.
+    await waitFor(() => {
+      const statusCalls = fetchSpy.mock.calls.filter(([url]) =>
+        /materialsTable\/(docsInProgress|successDocs)/.test(String(url)),
+      )
+      expect(statusCalls.length).toBeGreaterThanOrEqual(2)
+    })
     expect(invalidateSpy).not.toHaveBeenCalled()
   })
 
@@ -338,13 +345,10 @@ describe('WebsiteIngestForm', () => {
 
     const requestBodies: any[] = []
     server.use(
-      http.post(
-        '*/api/materialsTable/docsInProgress*',
-        async ({ request }) => {
-          requestBodies.push(await request.json())
-          return HttpResponse.json({ documents: [] })
-        },
-      ),
+      http.post('*/api/materialsTable/docsInProgress*', async ({ request }) => {
+        requestBodies.push(await request.json())
+        return HttpResponse.json({ documents: [] })
+      }),
       http.post('*/api/materialsTable/successDocs*', async ({ request }) => {
         requestBodies.push(await request.json())
         return HttpResponse.json({

--- a/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
@@ -281,6 +281,67 @@ describe('WebsiteIngestForm', () => {
     expect(setIntervalSpy).not.toHaveBeenCalled()
   })
 
+  it('does not refetch the documents table when a tick only discovers more in-progress URLs', async () => {
+    vi.spyOn(globalThis, 'setInterval').mockImplementation(((fn: any) => {
+      fn()
+      return 0
+    }) as any)
+
+    server.use(
+      // A live crawl keeps adding in-progress rows. Those are not in the
+      // documents table, so refetching it every tick is pure waste — the
+      // exact load pattern issue #90 is about.
+      http.post('*/api/materialsTable/docsInProgress*', async () => {
+        return HttpResponse.json({
+          documents: [
+            {
+              base_url: 'https://example.com',
+              url: 'https://example.com/page1',
+              readable_filename: 'page1',
+            },
+          ],
+        })
+      }),
+      http.post('*/api/materialsTable/successDocs*', async () => {
+        return HttpResponse.json({ documents: [] })
+      }),
+    )
+
+    const { default: WebsiteIngestForm } = await import('../WebsiteIngestForm')
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    renderWithProviders(
+      <Harness
+        Component={WebsiteIngestForm}
+        queryClient={queryClient}
+        initialFiles={[
+          {
+            name: 'https://example.com',
+            status: 'ingesting',
+            type: 'webscrape',
+            url: 'https://example.com',
+            isBaseUrl: true,
+          },
+        ]}
+      />,
+      { homeContext: { dispatch: vi.fn() }, queryClient },
+    )
+
+    // The new child entry must show up in the toast...
+    await waitFor(() => {
+      expect(screen.getByTestId('files').textContent ?? '').toContain(
+        'https://example.com/page1',
+      )
+    })
+
+    // ...without triggering the expensive documents refetch.
+    expect(
+      invalidateSpy.mock.calls.filter(([arg]: any[]) =>
+        String(arg?.queryKey?.[0]).startsWith('documents'),
+      ),
+    ).toHaveLength(0)
+  })
+
   it('does not invalidate queries on a no-change tick', async () => {
     vi.spyOn(globalThis, 'setInterval').mockImplementation(((fn: any) => {
       fn()

--- a/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
@@ -32,6 +32,7 @@ function Harness(props: any) {
       <div data-testid="files">{JSON.stringify(files)}</div>
       <props.Component
         project_name="CS101"
+        uploadFiles={files}
         setUploadFiles={setFiles}
         queryClient={props.queryClient}
       />
@@ -50,7 +51,7 @@ describe('WebsiteIngestForm', () => {
       })
 
     server.use(
-      http.get('*/api/materialsTable/docsInProgress*', async () => {
+      http.post('*/api/materialsTable/docsInProgress*', async () => {
         return HttpResponse.json({
           documents: [
             {
@@ -66,7 +67,7 @@ describe('WebsiteIngestForm', () => {
           ],
         })
       }),
-      http.get('*/api/materialsTable/successDocs*', async () => {
+      http.post('*/api/materialsTable/successDocs*', async () => {
         return HttpResponse.json({ documents: [] })
       }),
     )
@@ -107,10 +108,10 @@ describe('WebsiteIngestForm', () => {
     })
 
     server.use(
-      http.get('*/api/materialsTable/docsInProgress*', async () => {
+      http.post('*/api/materialsTable/docsInProgress*', async () => {
         return HttpResponse.json({ documents: [] })
       }),
-      http.get('*/api/materialsTable/successDocs*', async () => {
+      http.post('*/api/materialsTable/successDocs*', async () => {
         return HttpResponse.json({
           documents: [
             {
@@ -163,7 +164,7 @@ describe('WebsiteIngestForm', () => {
     })
 
     server.use(
-      http.get('*/api/materialsTable/docsInProgress*', async () => {
+      http.post('*/api/materialsTable/docsInProgress*', async () => {
         return HttpResponse.json({
           documents: [
             {
@@ -175,7 +176,7 @@ describe('WebsiteIngestForm', () => {
           ],
         })
       }),
-      http.get('*/api/materialsTable/successDocs*', async () => {
+      http.post('*/api/materialsTable/successDocs*', async () => {
         return HttpResponse.json({ documents: [] })
       }),
     )
@@ -215,10 +216,10 @@ describe('WebsiteIngestForm', () => {
     })
 
     server.use(
-      http.get('*/api/materialsTable/docsInProgress*', async () => {
+      http.post('*/api/materialsTable/docsInProgress*', async () => {
         return HttpResponse.json({ documents: [] })
       }),
-      http.get('*/api/materialsTable/successDocs*', async () => {
+      http.post('*/api/materialsTable/successDocs*', async () => {
         return HttpResponse.json({
           documents: [{ url: 'https://example.com' }],
         })
@@ -250,6 +251,164 @@ describe('WebsiteIngestForm', () => {
     })
   })
 
+  it('does not poll when no webscrape uploads are active', async () => {
+    const setIntervalSpy = vi
+      .spyOn(globalThis, 'setInterval')
+      .mockImplementation((fn: any) => {
+        fn()
+        // @ts-expect-error - minimal timer handle for tests
+        return 0
+      })
+
+    const { default: WebsiteIngestForm } = await import('../WebsiteIngestForm')
+    const queryClient = createTestQueryClient()
+    renderWithProviders(
+      <Harness
+        Component={WebsiteIngestForm}
+        queryClient={queryClient}
+        initialFiles={[
+          {
+            name: 'https://example.com',
+            status: 'complete',
+            type: 'webscrape',
+            url: 'https://example.com',
+            isBaseUrl: true,
+          },
+        ]}
+      />,
+      { homeContext: { dispatch: vi.fn() }, queryClient },
+    )
+
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not invalidate queries on a no-change tick', async () => {
+    vi.spyOn(globalThis, 'setInterval').mockImplementation((fn: any) => {
+      fn()
+      // @ts-expect-error - minimal timer handle for tests
+      return 0
+    })
+
+    server.use(
+      // The tracked file is still in progress: nothing changes this tick.
+      http.post('*/api/materialsTable/docsInProgress*', async () => {
+        return HttpResponse.json({
+          documents: [
+            {
+              base_url: 'https://example.com',
+              url: 'https://example.com',
+              readable_filename: 'base',
+            },
+          ],
+        })
+      }),
+      http.post('*/api/materialsTable/successDocs*', async () => {
+        return HttpResponse.json({ documents: [] })
+      }),
+    )
+
+    const { default: WebsiteIngestForm } = await import('../WebsiteIngestForm')
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    renderWithProviders(
+      <Harness
+        Component={WebsiteIngestForm}
+        queryClient={queryClient}
+        initialFiles={[
+          {
+            name: 'https://example.com',
+            status: 'ingesting',
+            type: 'webscrape',
+            url: 'https://example.com',
+            isBaseUrl: true,
+          },
+        ]}
+      />,
+      { homeContext: { dispatch: vi.fn() }, queryClient },
+    )
+
+    // Give the async tick a chance to finish.
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 50))
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it('keeps filtering on the base URL while children resolve after the base entry went terminal', async () => {
+    vi.spyOn(globalThis, 'setInterval').mockImplementation((fn: any) => {
+      fn()
+      // @ts-expect-error - minimal timer handle for tests
+      return 0
+    })
+
+    const requestBodies: any[] = []
+    server.use(
+      http.post(
+        '*/api/materialsTable/docsInProgress*',
+        async ({ request }) => {
+          requestBodies.push(await request.json())
+          return HttpResponse.json({ documents: [] })
+        },
+      ),
+      http.post('*/api/materialsTable/successDocs*', async ({ request }) => {
+        requestBodies.push(await request.json())
+        return HttpResponse.json({
+          documents: [
+            {
+              base_url: 'https://example.com',
+              url: 'https://example.com/child1',
+              readable_filename: 'child1',
+            },
+          ],
+        })
+      }),
+    )
+
+    const { default: WebsiteIngestForm } = await import('../WebsiteIngestForm')
+    const queryClient = createTestQueryClient()
+    renderWithProviders(
+      <Harness
+        Component={WebsiteIngestForm}
+        queryClient={queryClient}
+        initialFiles={[
+          {
+            // Base entry already terminal…
+            name: 'https://example.com',
+            status: 'complete',
+            type: 'webscrape',
+            url: 'https://example.com',
+            isBaseUrl: true,
+          },
+          {
+            // …while a child is still resolving (keeps the gate open).
+            name: 'https://example.com/child1',
+            status: 'ingesting',
+            type: 'webscrape',
+            url: 'https://example.com/child1',
+          },
+        ]}
+      />,
+      { homeContext: { dispatch: vi.fn() }, queryClient },
+    )
+
+    await waitFor(() => {
+      const filesJson = screen.getByTestId('files').textContent ?? ''
+      expect(filesJson).toContain('"status":"complete"')
+      expect(requestBodies.length).toBeGreaterThan(0)
+    })
+
+    // The filter must be keyed on the BASE entry's URL (children's rows carry
+    // it as base_url), not on the child URLs.
+    for (const body of requestBodies) {
+      expect(body).toEqual({
+        course_name: 'CS101',
+        base_urls: ['https://example.com'],
+      })
+    }
+
+    // And the child must have completed via the base_url-filtered results.
+    const filesJson = screen.getByTestId('files').textContent ?? ''
+    expect(filesJson).not.toContain('"status":"ingesting"')
+  })
+
   it('opens the dialog and starts ingestion via /api/scrapeWeb', async () => {
     const user = userEvent.setup()
     const axiosMod = await import('axios')
@@ -271,6 +430,7 @@ describe('WebsiteIngestForm', () => {
     renderWithProviders(
       <WebsiteIngestForm
         project_name="CS101"
+        uploadFiles={[]}
         setUploadFiles={vi.fn() as any}
         queryClient={queryClient}
       />,
@@ -318,6 +478,7 @@ describe('WebsiteIngestForm', () => {
     renderWithProviders(
       <WebsiteIngestForm
         project_name="CS101"
+        uploadFiles={[]}
         setUploadFiles={vi.fn() as any}
         queryClient={queryClient}
       />,

--- a/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
+++ b/apps/frontend/src/components/UIUC-Components/__tests__/WebsiteIngestForm.test.tsx
@@ -254,11 +254,10 @@ describe('WebsiteIngestForm', () => {
   it('does not poll when no webscrape uploads are active', async () => {
     const setIntervalSpy = vi
       .spyOn(globalThis, 'setInterval')
-      .mockImplementation((fn: any) => {
+      .mockImplementation(((fn: any) => {
         fn()
-        // @ts-expect-error - minimal timer handle for tests
         return 0
-      })
+      }) as any)
 
     const { default: WebsiteIngestForm } = await import('../WebsiteIngestForm')
     const queryClient = createTestQueryClient()
@@ -283,11 +282,10 @@ describe('WebsiteIngestForm', () => {
   })
 
   it('does not invalidate queries on a no-change tick', async () => {
-    vi.spyOn(globalThis, 'setInterval').mockImplementation((fn: any) => {
+    vi.spyOn(globalThis, 'setInterval').mockImplementation(((fn: any) => {
       fn()
-      // @ts-expect-error - minimal timer handle for tests
       return 0
-    })
+    }) as any)
 
     server.use(
       // The tracked file is still in progress: nothing changes this tick.
@@ -333,11 +331,10 @@ describe('WebsiteIngestForm', () => {
   })
 
   it('keeps filtering on the base URL while children resolve after the base entry went terminal', async () => {
-    vi.spyOn(globalThis, 'setInterval').mockImplementation((fn: any) => {
+    vi.spyOn(globalThis, 'setInterval').mockImplementation(((fn: any) => {
       fn()
-      // @ts-expect-error - minimal timer handle for tests
       return 0
-    })
+    }) as any)
 
     const requestBodies: any[] = []
     server.use(

--- a/apps/frontend/src/hooks/useGatedIngestPoller.ts
+++ b/apps/frontend/src/hooks/useGatedIngestPoller.ts
@@ -62,7 +62,6 @@ export function useGatedIngestPoller({
   })
 
   const wasActiveRef = useRef(false)
-  const invalidatedDocumentsRef = useRef(false)
 
   useEffect(() => {
     const invalidate = (key: 'documents' | 'failedDocuments') =>
@@ -71,17 +70,16 @@ export function useGatedIngestPoller({
     if (!isActive) {
       if (wasActiveRef.current) {
         // Gate just closed — final refresh, a backstop for anything the
-        // per-tick diffs missed (e.g. errors set outside the poller).
+        // per-tick diffs missed (e.g. a row that lands just after the file
+        // went terminal, or an error set outside the poller). Worth one
+        // possibly-redundant refetch per batch.
         wasActiveRef.current = false
-        // Skip if a tick already refreshed the table for this batch, so
-        // finishing an upload doesn't cancel and re-issue that refetch.
-        if (!invalidatedDocumentsRef.current) invalidate('documents')
+        invalidate('documents')
         invalidate('failedDocuments')
       }
       return
     }
     wasActiveRef.current = true
-    invalidatedDocumentsRef.current = false
 
     let inFlight = false
     // Results of a tick that was still in flight when the gate closed (or the
@@ -104,21 +102,20 @@ export function useGatedIngestPoller({
 
         const snapshot = filesRef.current
         const next = applyStatusRef.current(status, snapshot)
+        // Appended entries compare against `undefined`, so they are `changed`
+        // too — one signal covers both re-classified and newly-found files.
         const changed = next.filter((file, i) => file !== snapshot[i])
-        const added = next.length !== snapshot.length
 
         // A steady tick changes nothing; re-rendering the upload toast anyway
         // would defeat the point of this hook.
-        if (!added && changed.length === 0) return
+        if (changed.length === 0) return
 
         setUploadFiles((prev) => applyStatusRef.current(status, prev))
 
-        // Only completions can change the documents table. Appended entries
-        // are already in `changed` (they compare against `undefined`), so a
-        // tick that merely discovers more in-progress URLs — every tick of a
-        // live crawl — must not trigger the expensive table refetch.
+        // Only completions can change the documents table, so a tick that
+        // merely discovers more in-progress URLs — every tick of a live crawl
+        // — must not trigger the expensive table refetch.
         if (changed.some((file) => file.status === 'complete')) {
-          invalidatedDocumentsRef.current = true
           invalidate('documents')
         }
         if (changed.some((file) => file.status === 'error')) {

--- a/apps/frontend/src/hooks/useGatedIngestPoller.ts
+++ b/apps/frontend/src/hooks/useGatedIngestPoller.ts
@@ -137,10 +137,12 @@ export function useGatedIngestPoller({
       cancelled = true
       clearInterval(intervalId)
     }
-    // `queryClient` and `setUploadFiles` are deliberately omitted: both are
-    // stable, and depending on them would tear down and re-arm the interval on
-    // every parent render, which is exactly the polling churn this hook exists
-    // to prevent.
+    // `queryClient` and `setUploadFiles` are deliberately omitted. Their
+    // identities may change per render, but each only delegates to a stable
+    // target (the query cache, the state setter), so whichever instance the
+    // effect captured is equivalent. Depending on them would tear down and
+    // re-arm the interval on every parent render — exactly the polling churn
+    // this hook exists to prevent.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isActive, courseName, intervalMs])
 }

--- a/apps/frontend/src/hooks/useGatedIngestPoller.ts
+++ b/apps/frontend/src/hooks/useGatedIngestPoller.ts
@@ -9,6 +9,15 @@ import {
 } from '~/utils/ingestStatusClient'
 
 /**
+ * An upload of `type` this component is still waiting on. The gate, the
+ * server-side filter and the status mapping must all agree on this, or a file
+ * the tick never asked about could be reclassified from its results.
+ */
+export const isActiveUpload = (file: FileUpload, type: FileUpload['type']) =>
+  file.type === type &&
+  (file.status === 'uploading' || file.status === 'ingesting')
+
+/**
  * Polls the ingest-status endpoints ONLY while uploads of `type` are in
  * flight, and refreshes the documents table when a tick actually changes
  * something. Idle dashboards issue no requests at all.
@@ -38,11 +47,7 @@ export function useGatedIngestPoller({
   buildFilter: (files: FileUpload[]) => IngestStatusFilter
   applyStatus: (status: IngestStatus, files: FileUpload[]) => FileUpload[]
 }) {
-  const isActive = uploadFiles.some(
-    (file) =>
-      file.type === type &&
-      (file.status === 'uploading' || file.status === 'ingesting'),
-  )
+  const isActive = uploadFiles.some((file) => isActiveUpload(file, type))
 
   // Latest-value refs: the effect re-runs only when the gate flips, so
   // everything it reads per tick must come through a ref rather than the
@@ -57,6 +62,7 @@ export function useGatedIngestPoller({
   })
 
   const wasActiveRef = useRef(false)
+  const invalidatedDocumentsRef = useRef(false)
 
   useEffect(() => {
     const invalidate = (key: 'documents' | 'failedDocuments') =>
@@ -67,12 +73,15 @@ export function useGatedIngestPoller({
         // Gate just closed — final refresh, a backstop for anything the
         // per-tick diffs missed (e.g. errors set outside the poller).
         wasActiveRef.current = false
-        invalidate('documents')
+        // Skip if a tick already refreshed the table for this batch, so
+        // finishing an upload doesn't cancel and re-issue that refetch.
+        if (!invalidatedDocumentsRef.current) invalidate('documents')
         invalidate('failedDocuments')
       }
       return
     }
     wasActiveRef.current = true
+    invalidatedDocumentsRef.current = false
 
     let inFlight = false
     // Results of a tick that was still in flight when the gate closed (or the
@@ -104,7 +113,12 @@ export function useGatedIngestPoller({
 
         setUploadFiles((prev) => applyStatusRef.current(status, prev))
 
-        if (added || changed.some((file) => file.status === 'complete')) {
+        // Only completions can change the documents table. Appended entries
+        // are already in `changed` (they compare against `undefined`), so a
+        // tick that merely discovers more in-progress URLs — every tick of a
+        // live crawl — must not trigger the expensive table refetch.
+        if (changed.some((file) => file.status === 'complete')) {
+          invalidatedDocumentsRef.current = true
           invalidate('documents')
         }
         if (changed.some((file) => file.status === 'error')) {

--- a/apps/frontend/src/hooks/useGatedIngestPoller.ts
+++ b/apps/frontend/src/hooks/useGatedIngestPoller.ts
@@ -137,5 +137,10 @@ export function useGatedIngestPoller({
       cancelled = true
       clearInterval(intervalId)
     }
+    // `queryClient` and `setUploadFiles` are deliberately omitted: both are
+    // stable, and depending on them would tear down and re-arm the interval on
+    // every parent render, which is exactly the polling churn this hook exists
+    // to prevent.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isActive, courseName, intervalMs])
 }

--- a/apps/frontend/src/hooks/useGatedIngestPoller.ts
+++ b/apps/frontend/src/hooks/useGatedIngestPoller.ts
@@ -1,0 +1,126 @@
+import { useEffect, useRef } from 'react'
+import { type QueryClient } from '@tanstack/react-query'
+
+import { type FileUpload } from '~/components/UIUC-Components/UploadNotification'
+import {
+  fetchIngestStatus,
+  type IngestStatus,
+  type IngestStatusFilter,
+} from '~/utils/ingestStatusClient'
+
+/**
+ * Polls the ingest-status endpoints ONLY while uploads of `type` are in
+ * flight, and refreshes the documents table when a tick actually changes
+ * something. Idle dashboards issue no requests at all.
+ *
+ * `buildFilter` names the rows this component cares about so the endpoints
+ * can filter server-side instead of returning the whole documents table;
+ * `applyStatus` must be a pure `files -> files` mapping (it runs twice per
+ * tick: once on a snapshot to decide invalidation, once inside the state
+ * updater so entries appended mid-tick survive).
+ */
+export function useGatedIngestPoller({
+  courseName,
+  uploadFiles,
+  setUploadFiles,
+  queryClient,
+  type,
+  intervalMs,
+  buildFilter,
+  applyStatus,
+}: {
+  courseName: string
+  uploadFiles: FileUpload[]
+  setUploadFiles: React.Dispatch<React.SetStateAction<FileUpload[]>>
+  queryClient: QueryClient
+  type: FileUpload['type']
+  intervalMs: number
+  buildFilter: (files: FileUpload[]) => IngestStatusFilter
+  applyStatus: (status: IngestStatus, files: FileUpload[]) => FileUpload[]
+}) {
+  const isActive = uploadFiles.some(
+    (file) =>
+      file.type === type &&
+      (file.status === 'uploading' || file.status === 'ingesting'),
+  )
+
+  // Latest-value refs: the effect re-runs only when the gate flips, so
+  // everything it reads per tick must come through a ref rather than the
+  // closure of the render that opened the gate.
+  const filesRef = useRef(uploadFiles)
+  const buildFilterRef = useRef(buildFilter)
+  const applyStatusRef = useRef(applyStatus)
+  useEffect(() => {
+    filesRef.current = uploadFiles
+    buildFilterRef.current = buildFilter
+    applyStatusRef.current = applyStatus
+  })
+
+  const wasActiveRef = useRef(false)
+
+  useEffect(() => {
+    const invalidate = (key: 'documents' | 'failedDocuments') =>
+      void queryClient.invalidateQueries({ queryKey: [key, courseName] })
+
+    if (!isActive) {
+      if (wasActiveRef.current) {
+        // Gate just closed — final refresh, a backstop for anything the
+        // per-tick diffs missed (e.g. errors set outside the poller).
+        wasActiveRef.current = false
+        invalidate('documents')
+        invalidate('failedDocuments')
+      }
+      return
+    }
+    wasActiveRef.current = true
+
+    let inFlight = false
+    // Results of a tick that was still in flight when the gate closed (or the
+    // component unmounted) must be discarded: they describe a filter that no
+    // longer matches what is being tracked, so applying them could mark a
+    // healthy ingest as failed.
+    let cancelled = false
+
+    const checkIngestStatus = async () => {
+      if (inFlight) return
+      inFlight = true
+      try {
+        const status = await fetchIngestStatus(
+          courseName,
+          buildFilterRef.current(filesRef.current),
+        )
+        // Null means a request failed or there was nothing to ask about.
+        // Never read that as "the document vanished" — skip the tick.
+        if (!status || cancelled) return
+
+        const snapshot = filesRef.current
+        const next = applyStatusRef.current(status, snapshot)
+        const changed = next.filter((file, i) => file !== snapshot[i])
+        const added = next.length !== snapshot.length
+
+        // A steady tick changes nothing; re-rendering the upload toast anyway
+        // would defeat the point of this hook.
+        if (!added && changed.length === 0) return
+
+        setUploadFiles((prev) => applyStatusRef.current(status, prev))
+
+        if (added || changed.some((file) => file.status === 'complete')) {
+          invalidate('documents')
+        }
+        if (changed.some((file) => file.status === 'error')) {
+          invalidate('failedDocuments')
+        }
+      } catch (error) {
+        console.error('Error checking ingest status:', error)
+      } finally {
+        inFlight = false
+      }
+    }
+
+    const intervalId = setInterval(checkIngestStatus, intervalMs)
+    return () => {
+      cancelled = true
+      clearInterval(intervalId)
+    }
+  }, [isActive, courseName, intervalMs])
+}

--- a/apps/frontend/src/hooks/useGatedIngestPoller.ts
+++ b/apps/frontend/src/hooks/useGatedIngestPoller.ts
@@ -24,9 +24,8 @@ export const isActiveUpload = (file: FileUpload, type: FileUpload['type']) =>
  *
  * `buildFilter` names the rows this component cares about so the endpoints
  * can filter server-side instead of returning the whole documents table;
- * `applyStatus` must be a pure `files -> files` mapping (it runs twice per
- * tick: once on a snapshot to decide invalidation, once inside the state
- * updater so entries appended mid-tick survive).
+ * `applyStatus` must be a pure `files -> files` mapping, since it may be
+ * re-run inside the state updater when entries were appended mid-tick.
  */
 export function useGatedIngestPoller({
   courseName,
@@ -110,7 +109,12 @@ export function useGatedIngestPoller({
         // would defeat the point of this hook.
         if (changed.length === 0) return
 
-        setUploadFiles((prev) => applyStatusRef.current(status, prev))
+        // `next` already covers the common case; recompute only when entries
+        // were appended while the request was in flight, since applyStatus can
+        // be O(n·m) over a large crawl.
+        setUploadFiles((prev) =>
+          prev === snapshot ? next : applyStatusRef.current(status, prev),
+        )
 
         // Only completions can change the documents table, so a tick that
         // merely discovers more in-progress URLs — every tick of a live crawl

--- a/apps/frontend/src/pages/api/materialsTable/docsInProgress.ts
+++ b/apps/frontend/src/pages/api/materialsTable/docsInProgress.ts
@@ -1,15 +1,16 @@
-import { eq } from 'drizzle-orm'
+import { and, eq, inArray, or, sql } from 'drizzle-orm'
 import { type NextApiResponse } from 'next'
 import { type AuthenticatedRequest } from '~/utils/authMiddleware'
 import { documentsInProgress } from '~/db/dbClient'
 import { connectionManager } from '~/utils/connectionManager'
 import { withCourseOwnerOrAdminAccess } from '~/pages/api/authorization'
+import { parseIngestStatusFilters } from '~/utils/ingestStatusFilters'
 
 // This is for "Documents in Progress" table, docs that are still being ingested.
+// POST-only: callers must send the filenames/base_urls they are tracking.
 
 type DocsInProgressResponse = {
   documents?: { readable_filename: string; base_url: string; url: string }[]
-  apiKey?: null
   error?: string
 }
 
@@ -17,11 +18,15 @@ async function docsInProgress(
   req: AuthenticatedRequest,
   res: NextApiResponse<DocsInProgressResponse>,
 ) {
-  if (req.method !== 'GET') {
+  if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const course_name = req.query.course_name as string
+  const parsed = parseIngestStatusFilters(req.body)
+  if ('error' in parsed) {
+    return res.status(400).json({ error: parsed.error })
+  }
+  const { course_name, filenames, base_urls } = parsed
 
   try {
     const db = await connectionManager.getDocumentsDb(course_name)
@@ -32,24 +37,30 @@ async function docsInProgress(
         url: documentsInProgress.url,
       })
       .from(documentsInProgress)
-      .where(eq(documentsInProgress.course_name, course_name))
+      .where(
+        and(
+          eq(documentsInProgress.course_name, course_name),
+          or(
+            filenames.length
+              ? inArray(documentsInProgress.readable_filename, filenames)
+              : undefined,
+            base_urls.length
+              ? inArray(
+                  sql`rtrim(${documentsInProgress.base_url}, '/')`,
+                  base_urls,
+                )
+              : undefined,
+          ),
+        ),
+      )
 
-    // No need to check for error here as the query doesn't return an error object
-    // The try/catch block below will handle any errors that occur
-
-    if (!data || data.length === 0) {
-      return res.status(200).json({ documents: [] })
-    }
-
-    if (data && data.length > 0) {
-      return res.status(200).json({
-        documents: data.map((doc) => ({
-          readable_filename: doc.readable_filename || 'Untitled Document',
-          base_url: doc.base_url || '',
-          url: doc.url || '',
-        })),
-      })
-    }
+    return res.status(200).json({
+      documents: data.map((doc) => ({
+        readable_filename: doc.readable_filename || 'Untitled Document',
+        base_url: doc.base_url || '',
+        url: doc.url || '',
+      })),
+    })
   } catch (error) {
     console.error('Failed to fetch documents:', error)
     return res.status(500).json({

--- a/apps/frontend/src/pages/api/materialsTable/docsInProgress.ts
+++ b/apps/frontend/src/pages/api/materialsTable/docsInProgress.ts
@@ -26,7 +26,10 @@ async function docsInProgress(
   if ('error' in parsed) {
     return res.status(400).json({ error: parsed.error })
   }
-  const { course_name, filenames, base_urls } = parsed
+  const { filenames, base_urls } = parsed
+  // Query the course the middleware actually authorized, which is not
+  // necessarily the one in the body (it also accepts query params/headers).
+  const course_name = req.courseName ?? parsed.course_name
 
   try {
     const db = await connectionManager.getDocumentsDb(course_name)

--- a/apps/frontend/src/pages/api/materialsTable/successDocs.ts
+++ b/apps/frontend/src/pages/api/materialsTable/successDocs.ts
@@ -2,13 +2,14 @@ import { type NextApiResponse } from 'next'
 import { type AuthenticatedRequest } from '~/utils/authMiddleware'
 import { documents } from '~/db/dbClient'
 import { connectionManager } from '~/utils/connectionManager'
-import { eq } from 'drizzle-orm'
+import { and, eq, inArray, or, sql } from 'drizzle-orm'
 import { withCourseOwnerOrAdminAccess } from '~/pages/api/authorization'
-// This is for "Documents" table, completed docs.
+import { parseIngestStatusFilters } from '~/utils/ingestStatusFilters'
+// This is for "Documents" table, completed docs. POST-only: callers must send
+// the filenames/base_urls they are tracking so we never return the whole table.
 
 type SuccessDocsResponse = {
-  documents?: { readable_filename: string }[]
-  apiKey?: null
+  documents?: { readable_filename: string; base_url: string; url: string }[]
   error?: string
 }
 
@@ -16,11 +17,15 @@ async function successDocs(
   req: AuthenticatedRequest,
   res: NextApiResponse<SuccessDocsResponse>,
 ) {
-  if (req.method !== 'GET') {
+  if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const course_name = req.query.course_name as string
+  const parsed = parseIngestStatusFilters(req.body)
+  if ('error' in parsed) {
+    return res.status(400).json({ error: parsed.error })
+  }
+  const { course_name, filenames, base_urls } = parsed
 
   try {
     const db = await connectionManager.getDocumentsDb(course_name)
@@ -31,21 +36,27 @@ async function successDocs(
         url: documents.url,
       })
       .from(documents)
-      .where(eq(documents.course_name, course_name))
+      .where(
+        and(
+          eq(documents.course_name, course_name),
+          or(
+            filenames.length
+              ? inArray(documents.readable_filename, filenames)
+              : undefined,
+            base_urls.length
+              ? inArray(sql`rtrim(${documents.base_url}, '/')`, base_urls)
+              : undefined,
+          ),
+        ),
+      )
 
-    if (!data || data.length === 0) {
-      return res.status(200).json({ documents: [] })
-    }
-
-    if (data && data.length > 0) {
-      return res.status(200).json({
-        documents: data.map((doc) => ({
-          readable_filename: doc.readable_filename || '',
-          base_url: doc.base_url || '',
-          url: doc.url || '',
-        })),
-      })
-    }
+    return res.status(200).json({
+      documents: data.map((doc) => ({
+        readable_filename: doc.readable_filename || '',
+        base_url: doc.base_url || '',
+        url: doc.url || '',
+      })),
+    })
   } catch (error) {
     console.error('Failed to fetch documents:', error)
     return res.status(500).json({

--- a/apps/frontend/src/pages/api/materialsTable/successDocs.ts
+++ b/apps/frontend/src/pages/api/materialsTable/successDocs.ts
@@ -25,7 +25,10 @@ async function successDocs(
   if ('error' in parsed) {
     return res.status(400).json({ error: parsed.error })
   }
-  const { course_name, filenames, base_urls } = parsed
+  const { filenames, base_urls } = parsed
+  // Query the course the middleware actually authorized, which is not
+  // necessarily the one in the body (it also accepts query params/headers).
+  const course_name = req.courseName ?? parsed.course_name
 
   try {
     const db = await connectionManager.getDocumentsDb(course_name)

--- a/apps/frontend/src/test-utils/nextApi.ts
+++ b/apps/frontend/src/test-utils/nextApi.ts
@@ -7,6 +7,8 @@ export type MockNextApiRequest = Partial<NextApiRequest> & {
   body?: any
   headers?: Record<string, any>
   user?: any
+  /** Set by the course-access middleware once it has authorized the request. */
+  courseName?: string
 }
 
 export function createMockReq(overrides: MockNextApiRequest = {}) {

--- a/apps/frontend/src/utils/__tests__/ingestStatusFilters.test.ts
+++ b/apps/frontend/src/utils/__tests__/ingestStatusFilters.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAX_FILTER_ITEMS,
+  parseIngestStatusFilters,
+} from '../ingestStatusFilters'
+
+describe('parseIngestStatusFilters', () => {
+  it('strips trailing slashes so a user-entered URL matches the stored base_url', () => {
+    const parsed = parseIngestStatusFilters({
+      course_name: 'CS101',
+      base_urls: ['https://a.com/', 'https://b.com///', 'https://c.com'],
+    })
+
+    expect(parsed).toEqual({
+      course_name: 'CS101',
+      filenames: [],
+      // Must mirror the routes' rtrim(base_url, '/') — otherwise a crawl
+      // entered with a trailing slash never matches its own rows.
+      base_urls: ['https://a.com', 'https://b.com', 'https://c.com'],
+    })
+  })
+
+  it('keeps filenames verbatim, including ones that look like paths', () => {
+    const parsed = parseIngestStatusFilters({
+      course_name: 'CS101',
+      filenames: ['notes/', 'a,b.pdf'],
+    })
+
+    expect(parsed).toMatchObject({ filenames: ['notes/', 'a,b.pdf'] })
+  })
+
+  it('drops entries that cannot match instead of failing the request', () => {
+    expect(
+      parseIngestStatusFilters({
+        course_name: 'CS101',
+        filenames: ['', 'Doc A'],
+        base_urls: ['/'],
+      }),
+    ).toEqual({ course_name: 'CS101', filenames: ['Doc A'], base_urls: [] })
+  })
+
+  it('rejects a request whose filters all drop out', () => {
+    // Freezing the caller's statuses would be worse, but there is nothing to
+    // query, so the client is expected to skip the tick rather than send this.
+    expect(
+      parseIngestStatusFilters({ course_name: 'CS101', base_urls: ['/'] }),
+    ).toEqual({
+      error: 'At least one filter (filenames or base_urls) is required',
+    })
+  })
+
+  it.each([
+    ['missing course_name', { filenames: ['a.pdf'] }],
+    ['blank course_name', { course_name: '', filenames: ['a.pdf'] }],
+    ['non-array filenames', { course_name: 'CS101', filenames: 'a.pdf' }],
+    ['non-string entries', { course_name: 'CS101', base_urls: [42] }],
+    ['no filters at all', { course_name: 'CS101' }],
+  ])('rejects %s', (_label, body) => {
+    expect(parseIngestStatusFilters(body)).toHaveProperty('error')
+  })
+
+  it('caps the combined filter size', () => {
+    const names = Array.from({ length: MAX_FILTER_ITEMS }, (_, i) => `f${i}`)
+
+    expect(
+      parseIngestStatusFilters({ course_name: 'CS101', filenames: names }),
+    ).not.toHaveProperty('error')
+
+    expect(
+      parseIngestStatusFilters({
+        course_name: 'CS101',
+        filenames: names,
+        base_urls: ['https://a.com'],
+      }),
+    ).toHaveProperty('error')
+  })
+})

--- a/apps/frontend/src/utils/ingestStatusClient.ts
+++ b/apps/frontend/src/utils/ingestStatusClient.ts
@@ -76,15 +76,18 @@ export async function fetchIngestStatus(
 
   const inProgress: IngestStatusDoc[] = []
   const completed: IngestStatusDoc[] = []
-  // Chunks run sequentially on purpose: this endpoint hits a per-project
-  // Postgres whose connection pool is what issue #90 was exhausting, so a
-  // huge upload should take longer rather than fan out.
+  // Everything here is sequential on purpose. The endpoints hit a per-project
+  // Postgres whose connection pool is what issue #90 was exhausting, so a huge
+  // upload should take longer rather than fan out. More importantly, ingest
+  // writes the document row BEFORE deleting the in-progress row, so reading
+  // in-progress first is what guarantees a document that finishes mid-tick is
+  // seen in one list or the other. Reading them concurrently would let a
+  // completing document fall through both and be reported as failed.
   for (const body of bodies) {
-    const [progressDocs, completedDocs] = await Promise.all([
-      postStatus('docsInProgress', body),
-      postStatus('successDocs', body),
-    ])
-    if (progressDocs === null || completedDocs === null) return null
+    const progressDocs = await postStatus('docsInProgress', body)
+    if (progressDocs === null) return null
+    const completedDocs = await postStatus('successDocs', body)
+    if (completedDocs === null) return null
     inProgress.push(...progressDocs)
     completed.push(...completedDocs)
   }

--- a/apps/frontend/src/utils/ingestStatusClient.ts
+++ b/apps/frontend/src/utils/ingestStatusClient.ts
@@ -1,0 +1,77 @@
+import { MAX_FILTER_ITEMS } from '~/utils/ingestStatusFilters'
+
+// Client for the POST-only ingest-status routes. Callers send only the
+// filenames/base_urls they are tracking; oversized filters are chunked so a
+// large folder drop is never silently truncated (a tracked file missing from
+// the results would be misread as a failed ingest).
+
+export type IngestStatusDoc = {
+  readable_filename: string
+  base_url: string
+  url: string
+}
+
+export type IngestStatus = {
+  inProgress: IngestStatusDoc[]
+  completed: IngestStatusDoc[]
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size))
+  }
+  return chunks
+}
+
+async function postStatus(
+  endpoint: 'docsInProgress' | 'successDocs',
+  body: Record<string, unknown>,
+): Promise<IngestStatusDoc[] | null> {
+  const response = await fetch(`/api/materialsTable/${endpoint}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) return null
+  const data = await response.json()
+  return data?.documents ?? []
+}
+
+/**
+ * Fetch in-progress and completed docs matching the given filters.
+ * Returns null if ANY request fails — callers must then skip the whole
+ * status update rather than act on partial results.
+ */
+export async function fetchIngestStatus(
+  course_name: string,
+  filter: { filenames?: string[]; base_urls?: string[] },
+): Promise<IngestStatus | null> {
+  const filenames = (filter.filenames ?? []).filter((name) => name.length > 0)
+  const base_urls = (filter.base_urls ?? []).filter((url) => url.length > 0)
+
+  const bodies: Record<string, unknown>[] = [
+    ...chunk(filenames, MAX_FILTER_ITEMS).map((names) => ({
+      course_name,
+      filenames: names,
+    })),
+    ...chunk(base_urls, MAX_FILTER_ITEMS).map((urls) => ({
+      course_name,
+      base_urls: urls,
+    })),
+  ]
+  if (bodies.length === 0) return null
+
+  const inProgress: IngestStatusDoc[] = []
+  const completed: IngestStatusDoc[] = []
+  for (const body of bodies) {
+    const [progressDocs, completedDocs] = await Promise.all([
+      postStatus('docsInProgress', body),
+      postStatus('successDocs', body),
+    ])
+    if (progressDocs === null || completedDocs === null) return null
+    inProgress.push(...progressDocs)
+    completed.push(...completedDocs)
+  }
+  return { inProgress, completed }
+}

--- a/apps/frontend/src/utils/ingestStatusClient.ts
+++ b/apps/frontend/src/utils/ingestStatusClient.ts
@@ -76,6 +76,9 @@ export async function fetchIngestStatus(
 
   const inProgress: IngestStatusDoc[] = []
   const completed: IngestStatusDoc[] = []
+  // Chunks run sequentially on purpose: this endpoint hits a per-project
+  // Postgres whose connection pool is what issue #90 was exhausting, so a
+  // huge upload should take longer rather than fan out.
   for (const body of bodies) {
     const [progressDocs, completedDocs] = await Promise.all([
       postStatus('docsInProgress', body),

--- a/apps/frontend/src/utils/ingestStatusClient.ts
+++ b/apps/frontend/src/utils/ingestStatusClient.ts
@@ -16,6 +16,11 @@ export type IngestStatus = {
   completed: IngestStatusDoc[]
 }
 
+export type IngestStatusFilter = {
+  filenames?: string[]
+  base_urls?: string[]
+}
+
 function chunk<T>(items: T[], size: number): T[][] {
   const chunks: T[][] = []
   for (let i = 0; i < items.length; i += size) {
@@ -24,18 +29,25 @@ function chunk<T>(items: T[], size: number): T[][] {
   return chunks
 }
 
+/** Returns null on any failure — never throws, so concurrent calls can't
+ * leave an unobserved rejection behind. */
 async function postStatus(
   endpoint: 'docsInProgress' | 'successDocs',
   body: Record<string, unknown>,
 ): Promise<IngestStatusDoc[] | null> {
-  const response = await fetch(`/api/materialsTable/${endpoint}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-  if (!response.ok) return null
-  const data = await response.json()
-  return data?.documents ?? []
+  try {
+    const response = await fetch(`/api/materialsTable/${endpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!response.ok) return null
+    const data = await response.json()
+    return data?.documents ?? []
+  } catch (error) {
+    console.error(`Failed to fetch ${endpoint}:`, error)
+    return null
+  }
 }
 
 /**
@@ -45,7 +57,7 @@ async function postStatus(
  */
 export async function fetchIngestStatus(
   course_name: string,
-  filter: { filenames?: string[]; base_urls?: string[] },
+  filter: IngestStatusFilter,
 ): Promise<IngestStatus | null> {
   const filenames = (filter.filenames ?? []).filter((name) => name.length > 0)
   const base_urls = (filter.base_urls ?? []).filter((url) => url.length > 0)

--- a/apps/frontend/src/utils/ingestStatusFilters.ts
+++ b/apps/frontend/src/utils/ingestStatusFilters.ts
@@ -1,0 +1,71 @@
+// Shared request validation for the ingest-status polling routes
+// (materialsTable/successDocs and materialsTable/docsInProgress).
+// These routes are POST-only and REQUIRE at least one filter — there is no
+// unfiltered mode, so a large project can never be streamed back wholesale.
+
+export const MAX_FILTER_ITEMS = 1000
+
+const stripTrailingSlashes = (value: string) => value.replace(/\/+$/, '')
+
+function toStringArray(value: unknown): string[] | null {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) return null
+  const items: string[] = []
+  for (const item of value) {
+    if (typeof item !== 'string' || item.length === 0) return null
+    items.push(item)
+  }
+  return items
+}
+
+export type IngestStatusFilters = {
+  course_name: string
+  filenames: string[]
+  /** Normalized (trailing slashes stripped) — compare against rtrim(base_url, '/'). */
+  base_urls: string[]
+}
+
+export function parseIngestStatusFilters(
+  body: unknown,
+): IngestStatusFilters | { error: string } {
+  const { course_name, filenames, base_urls } = (body ?? {}) as Record<
+    string,
+    unknown
+  >
+
+  if (typeof course_name !== 'string' || course_name.length === 0) {
+    return { error: 'course_name is required' }
+  }
+
+  const parsedFilenames = toStringArray(filenames)
+  if (parsedFilenames === null) {
+    return { error: 'filenames must be an array of non-empty strings' }
+  }
+
+  const parsedBaseUrls = toStringArray(base_urls)
+  if (parsedBaseUrls === null) {
+    return { error: 'base_urls must be an array of non-empty strings' }
+  }
+
+  const normalizedBaseUrls = parsedBaseUrls
+    .map(stripTrailingSlashes)
+    .filter((url) => url.length > 0)
+
+  if (parsedFilenames.length === 0 && normalizedBaseUrls.length === 0) {
+    return {
+      error: 'At least one filter (filenames or base_urls) is required',
+    }
+  }
+
+  if (parsedFilenames.length + normalizedBaseUrls.length > MAX_FILTER_ITEMS) {
+    return {
+      error: `Too many filter items (max ${MAX_FILTER_ITEMS} combined)`,
+    }
+  }
+
+  return {
+    course_name,
+    filenames: parsedFilenames,
+    base_urls: normalizedBaseUrls,
+  }
+}

--- a/apps/frontend/src/utils/ingestStatusFilters.ts
+++ b/apps/frontend/src/utils/ingestStatusFilters.ts
@@ -8,14 +8,11 @@ export const MAX_FILTER_ITEMS = 1000
 const stripTrailingSlashes = (value: string) => value.replace(/\/+$/, '')
 
 function toStringArray(value: unknown): string[] | null {
-  if (value === undefined || value === null) return []
+  if (value == null) return []
   if (!Array.isArray(value)) return null
-  const items: string[] = []
-  for (const item of value) {
-    if (typeof item !== 'string' || item.length === 0) return null
-    items.push(item)
-  }
-  return items
+  return value.every((item) => typeof item === 'string')
+    ? (value as string[])
+    : null
 }
 
 export type IngestStatusFilters = {
@@ -39,25 +36,31 @@ export function parseIngestStatusFilters(
 
   const parsedFilenames = toStringArray(filenames)
   if (parsedFilenames === null) {
-    return { error: 'filenames must be an array of non-empty strings' }
+    return { error: 'filenames must be an array of strings' }
   }
 
   const parsedBaseUrls = toStringArray(base_urls)
   if (parsedBaseUrls === null) {
-    return { error: 'base_urls must be an array of non-empty strings' }
+    return { error: 'base_urls must be an array of strings' }
   }
 
+  // Entries that are empty (or empty once normalized) can't match anything, so
+  // drop them rather than failing the whole request — a 400 would freeze the
+  // caller's upload statuses.
+  const nonEmptyFilenames = parsedFilenames.filter((name) => name.length > 0)
   const normalizedBaseUrls = parsedBaseUrls
     .map(stripTrailingSlashes)
     .filter((url) => url.length > 0)
 
-  if (parsedFilenames.length === 0 && normalizedBaseUrls.length === 0) {
+  if (nonEmptyFilenames.length === 0 && normalizedBaseUrls.length === 0) {
     return {
       error: 'At least one filter (filenames or base_urls) is required',
     }
   }
 
-  if (parsedFilenames.length + normalizedBaseUrls.length > MAX_FILTER_ITEMS) {
+  // Combined cap. The client chunks each kind separately and never mixes both
+  // in one body, so a well-behaved caller can't trip this.
+  if (nonEmptyFilenames.length + normalizedBaseUrls.length > MAX_FILTER_ITEMS) {
     return {
       error: `Too many filter items (max ${MAX_FILTER_ITEMS} combined)`,
     }
@@ -65,7 +68,7 @@ export function parseIngestStatusFilters(
 
   return {
     course_name,
-    filenames: parsedFilenames,
+    filenames: nonEmptyFilenames,
     base_urls: normalizedBaseUrls,
   }
 }


### PR DESCRIPTION
Fixes #90.

Opening a project dashboard generated constant load on the documents database even when the user was idle, and for a large project the `successDocs` response exceeded Next.js's 4 MB API limit.

## What was happening

Per open dashboard, at idle:

- `LargeDropzone` polled `docsInProgress` **and** `successDocs` every 9s from mount, forever. Its adaptive-interval logic was dead code (the interval was armed once with the initial value), there was no overlap guard, and no response checks.
- `WebsiteIngestForm` and `GitHubIngestForm` each polled both endpoints every 3s, and every tick ended with an unconditional `invalidateQueries(['documents', project_name])`. That prefix-matches the table's query, so `fetchProjectMaterials` (a leftJoin plus `count(distinct id)`) refetched roughly every 3s regardless of activity.
- `successDocs` selected every document row for the course with no filter or limit.
- `ProjectFilesTable` refetched documents every 12s and failed documents every 20s, each running count queries.

All of it goes through the per-project connection manager, so the cost landed on external customer databases too.

## What changed

**Endpoints are POST-only and require filters.** Callers send the filenames or base URLs they are actually tracking (max 1000 combined); the routes filter with `IN` clauses, matching base URLs against `rtrim(base_url, '/')` to mirror the client's trailing-slash normalization. There is no unfiltered mode left. The routes also query `req.courseName` — the course the auth middleware authorized — rather than the body's, which closes a pre-existing cross-project read.

**Polling is gated on active uploads.** The three pollers share a new `useGatedIngestPoller` hook: it runs only while uploads of its type are in flight, guards against overlapping ticks, discards results from a tick that was torn down, skips state updates when nothing changed, and refreshes the table only when a file actually completes. An idle dashboard now issues zero requests to these endpoints.

**The table refreshes on a 5-minute interval** plus window-focus refetch, with a refresh button that refetches immediately (react-query re-arms the interval after each successful fetch, so this also restarts the countdown). During uploads the pollers invalidate on every real change, so the table is actually more responsive than before while active.

Two ordering constraints are load-bearing and are now enforced and tested: the in-progress read must precede the completed read (ingest writes the document row before deleting the in-progress row, so reading them concurrently can lose a document that finishes mid-tick and report it as failed), and a status response may only reclassify files that tick actually asked about.

Also removes dead code encountered along the way: the adaptive-interval logic, unused imports/state, a duplicated status-transition block, an unreachable redirect branch, and the `@types/react-query` devDependency (with the lockfile regenerated, which `npm ci` needs).

## Behavior changes worth knowing

- Idle table freshness moves to 5 minutes plus focus refetch and the refresh button. The effective idle freshness before was ~3s, because the ingest pollers forced a refetch every tick. This includes the failed-documents badge.
- Canvas ingests are queued behind manual admin approval, so their rows land minutes to hours later and now surface on the 5-minute tick, on focus, or via the refresh button.
- Closing the upload toast mid-ingest stops polling for those files (their statuses are discarded when the toast closes).
- Transient API failures no longer flip in-flight files to "error" — previously a failed request read as "the document vanished".

## Testing

`npx vitest run` — 512 tests pass across the touched suites. The full suite's only failures are four files (`authMiddleware`, `appRouterAuth`, `Search`, `Conversations`) that fail identically on `main`. `npx tsc --noEmit` reports 235 errors against a 238 baseline on `main`.

Each fix has a test that fails when the fix is reverted, including the stale-tick misclassification, the partial-chunk merge, the read ordering, and the auth precedence.
