### PR TITLE
Ingest worker PDF hardening: isolate ingest in a watchdogged subprocess, add HTTP ingest bridge

### DIFF
--- a/apps/backend/ai_ta_backend/rabbitmq/bridge.py
+++ b/apps/backend/ai_ta_backend/rabbitmq/bridge.py
@@ -1,0 +1,70 @@
+"""
+Minimal HTTP -> RabbitMQ ingest bridge.
+
+Exposes a single POST /ingest endpoint that mirrors the backend's /ingest route:
+it inserts a `documents_in_progress` row and publishes the job to RabbitMQ by
+reusing `rmqueue.Queue.addJobToIngestQueue`. External producers (the Crawlee
+service via INGEST_URL, migration scripts) can therefore drive ingest without
+the full Flask backend deployed.
+
+Runs from the same image as worker.py (same build context); the ECS bridge
+service simply overrides the command to `python bridge.py`.
+
+Environment (identical to the worker):
+  RABBITMQ_URL / RABBITMQ_QUEUE / RABBITMQ_SSL   -> Amazon MQ broker + queue
+  POSTGRES_ENDPOINT/PORT/DATABASE/USERNAME/PASSWORD -> documents DB
+"""
+import logging
+import os
+
+from flask import Flask, jsonify, request
+
+try:
+    from ai_ta_backend.rabbitmq.rmqueue import Queue
+except ModuleNotFoundError:  # standalone container: rabbitmq dir is the workdir
+    from rmqueue import Queue
+
+logging.basicConfig(level=logging.INFO)
+
+# Optional bearer-token auth. When INGEST_API_KEY is set (recommended for a
+# public/internet-facing deployment), callers must send
+# `Authorization: Bearer <INGEST_API_KEY>`. Crawlee already sends this header
+# (its BEAM_API_KEY must equal INGEST_API_KEY). If unset, the endpoint is open.
+INGEST_API_KEY = os.getenv("INGEST_API_KEY")
+
+app = Flask(__name__)
+
+
+@app.route('/api/healthcheck', methods=['GET'])
+def healthcheck():
+    return jsonify({"status": "OK"}), 200
+
+
+@app.route('/ingest', methods=['POST'])
+def ingest():
+    """Queue an ingest job. Accepts the same payload as the backend /ingest:
+    course_name, readable_filename, s3_paths | content | url, base_url, groups, ...
+    """
+    if INGEST_API_KEY and request.headers.get("Authorization", "") != f"Bearer {INGEST_API_KEY}":
+        return jsonify({"error": "unauthorized"}), 401
+
+    data = request.get_json(force=True, silent=True)
+    if not data or not data.get('course_name'):
+        return jsonify({"error": "missing JSON body or 'course_name'"}), 400
+
+    # addJobToIngestQueue reads inputs['readable_filename'] unconditionally.
+    data.setdefault('readable_filename', '')
+
+    try:
+        # One short-lived AMQP connection per request keeps this thread-safe under
+        # Flask's threaded server (pika BlockingConnection is not thread-safe).
+        with Queue() as queue:
+            task_id = queue.addJobToIngestQueue(data)
+        return jsonify({"outcome": "Queued Ingest task", "task_id": task_id}), 200
+    except Exception as exc:  # noqa: BLE001 - surface any failure to the caller
+        logging.exception("Failed to queue ingest job")
+        return jsonify({"error": str(exc)}), 500
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8001, threaded=True)

--- a/apps/backend/ai_ta_backend/rabbitmq/worker.py
+++ b/apps/backend/ai_ta_backend/rabbitmq/worker.py
@@ -6,10 +6,11 @@ from typing import List, Optional
 import pika
 import logging
 import json
+import sys
 import threading
+import multiprocessing as mp
 
 from rmsql import SQLAlchemyIngestDB
-from ingest import Ingest
 from connection_resolver import WorkerConnectionResolver
 from flask import Flask, jsonify
 
@@ -24,6 +25,49 @@ worker_running = threading.Event()
 
 
 logging.getLogger('pika').setLevel(logging.WARNING)
+
+INGEST_TIMEOUT = int(os.getenv('INGEST_SUBPROCESS_TIMEOUT', '300'))  # seconds; per-doc OCR watchdog cap
+
+
+def _ingest_child(job_id, inputs):
+    """Runs in a spawned subprocess: fresh Ingest() (no inherited fds/threads), do the work.
+
+    Connections are re-resolved here rather than passed in: a ResolvedConnections holds
+    live SQLAlchemy engines / Qdrant / boto3 clients, none of which survive pickling
+    across the spawn boundary.
+    """
+    try:
+        from ingest import Ingest as _Ingest
+        from rmsql import SQLAlchemyIngestDB as _SQLAlchemyIngestDB
+        from connection_resolver import WorkerConnectionResolver as _Resolver
+
+        resolved = _Resolver(_SQLAlchemyIngestDB()).resolve(inputs.get('course_name', ''))
+        _Ingest().main_ingest(job_id=job_id, _resolved_connections=resolved, **inputs)
+        sys.exit(0)
+    except Exception:
+        logging.error("Ingest child exception:\n%s", traceback.format_exc())
+        sys.exit(3)
+
+
+def run_ingest_isolated(job_id, inputs):
+    """Run main_ingest in a spawned child with a hard timeout so a hung/huge OCR can't block the
+    consumer thread (RabbitMQ heartbeats) or the Flask ALB health check, and a native segfault in
+    the OCR libs kills only the child. Returns None on clean completion, else an error string."""
+    ctx = mp.get_context('spawn')  # spawn, NOT fork: worker is multithreaded (Flask) -> fork can deadlock
+    p = ctx.Process(target=_ingest_child, args=(job_id, inputs))
+    p.start()
+    p.join(INGEST_TIMEOUT)
+    if p.is_alive():
+        p.kill()
+        p.join(10)
+        return (f"OCR/ingest exceeded {INGEST_TIMEOUT}s limit and was killed "
+                f"(likely a very large/complex PDF OCR).")
+    if p.exitcode is not None and p.exitcode < 0:
+        return (f"OCR/ingest subprocess crashed: killed by signal {-p.exitcode} "
+                f"(e.g. segfault in the PDF/OCR native libraries).")
+    if p.exitcode not in (0, None):
+        return f"OCR/ingest subprocess exited abnormally (exit {p.exitcode}); see worker logs."
+    return None
 
 
 class Worker:
@@ -50,6 +94,10 @@ class Worker:
 
     def connect(self):
         parameters = pika.URLParameters(self.rabbitmq_url)
+        # Keep the connection alive across the long (up to INGEST_TIMEOUT) subprocess wait so
+        # RabbitMQ doesn't drop us mid-OCR and redeliver the message (which the redelivery guard
+        # would then mislabel as "worker crashed").
+        parameters.heartbeat = max(900, INGEST_TIMEOUT * 3)
         if self.rabbitmq_ssl:
             # Necessary for AWS AmazonMQ
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
@@ -131,8 +179,22 @@ class Worker:
                     prog_doc["error"] = 'Attempting ingest'
                     status_db.update_document_in_progress(prog_doc)
 
-                    ingester = Ingest()
-                    ingester.main_ingest(job_id=job_id, _resolved_connections=resolved, **inputs)
+                    # Run ingest (incl. OCR) in an isolated, time-boxed subprocess so a hung/huge
+                    # OCR can't block RabbitMQ heartbeats or the ALB health check, and a native
+                    # segfault kills only the child. On timeout/crash: record a clear failure and
+                    # ack (no requeue -> no redelivery-guard mislabel).
+                    failure = run_ingest_isolated(job_id, inputs)
+                    if failure is not None:
+                        status_db.insert_failed_document({
+                            "s3_path": str(prog_doc["s3_path"]),
+                            "readable_filename": prog_doc["readable_filename"],
+                            "course_name": prog_doc["course_name"],
+                            "url": prog_doc["url"],
+                            "base_url": prog_doc["base_url"],
+                            "doc_groups": prog_doc["doc_groups"],
+                            "error": failure,
+                        })
+                        status_db.delete_document_in_progress(job_id)
                     channel.basic_ack(delivery_tag=method.delivery_tag)
         except Exception as e:
             if retry_count < MAX_JOB_RETRIES:

--- a/apps/backend/docs/SUMMARY.md
+++ b/apps/backend/docs/SUMMARY.md
@@ -34,6 +34,7 @@
 
 * [Developer Quickstart](developers/developer-quickstart.md)
 * [External Connections Config](developers/external-connections-config.md)
+* [Lightweight Ingest via the HTTP Bridge](developers/lightweight-ingest-bridge.md)
 
 ## MIGRATION
 

--- a/apps/backend/docs/developers/lightweight-ingest-bridge.md
+++ b/apps/backend/docs/developers/lightweight-ingest-bridge.md
@@ -1,0 +1,135 @@
+---
+description: >-
+  Run a lightweight document ingest for any course with the HTTP ingest bridge
+  (bridge.py) and the RabbitMQ worker — no full Flask backend required.
+layout:
+  title:
+    visible: true
+  description:
+    visible: true
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Lightweight Ingest via the HTTP Bridge
+
+`ai_ta_backend/rabbitmq/bridge.py` is a minimal HTTP front door for the ingest
+pipeline. It exposes a single `POST /ingest` endpoint that mirrors the main
+backend's `/ingest` route: it inserts a `documents_in_progress` row and
+publishes the job to RabbitMQ, where the ingest worker (`worker.py`) picks it
+up. That means you can drive a full ingest for **any course** — bulk document
+loads, migrations, re-ingests — without deploying the entire Flask backend.
+
+This is the same endpoint the Crawlee service targets via `INGEST_URL`, so
+anything you can crawl-ingest you can also ingest by hand through the bridge.
+
+## When to use it
+
+* Bulk-ingesting an existing corpus (e.g. thousands of PDFs already sitting in
+  S3) into a course.
+* Re-ingesting documents after a pipeline or schema change.
+* Migration scripts that need to queue ingest jobs from outside the main
+  deployment.
+* Any environment where you want the ingest path up quickly: broker + database
+  \+ worker + bridge is the whole footprint.
+
+## How it fits together
+
+```
+your script / Crawlee ──POST /ingest──▶ bridge.py ──▶ documents_in_progress row (Postgres)
+                                                  └─▶ RabbitMQ queue ──▶ worker.py ──▶ per-doc ingest subprocess
+```
+
+The worker runs each document in a time-boxed subprocess (default 300s,
+`INGEST_SUBPROCESS_TIMEOUT`), so a hung or segfaulting PDF/OCR job kills only
+that document's child process — the queue keeps draining.
+
+Per-course infrastructure (S3 bucket, vector store, embeddings, documents DB)
+is resolved by the worker at job time from the course's
+[external connections config](external-connections-config.md), with the
+host defaults used for courses that have none.
+
+## Running the bridge
+
+The bridge runs from the **same image as the worker** (same build context,
+`ai_ta_backend/rabbitmq/Dockerfile`); the bridge service simply overrides the
+command:
+
+```bash
+python bridge.py   # serves on 0.0.0.0:8001
+```
+
+Environment (identical to the worker):
+
+| Variable | Purpose |
+| --- | --- |
+| `RABBITMQ_URL` | AMQP broker URL (default `amqp://guest:guest@localhost:5672`) |
+| `RABBITMQ_QUEUE` | Queue name (default `uiuc-chat`) |
+| `RABBITMQ_SSL` | Set truthy for TLS brokers (e.g. Amazon MQ) |
+| `POSTGRES_ENDPOINT` / `POSTGRES_PORT` / `POSTGRES_DATABASE` / `POSTGRES_USERNAME` / `POSTGRES_PASSWORD` | Documents DB for the `documents_in_progress` status rows |
+| `INGEST_API_KEY` | Optional bearer token. If set, callers must send `Authorization: Bearer <key>`. Strongly recommended for anything internet-facing; if unset the endpoint is open. |
+
+For local experiments, `ai_ta_backend/rabbitmq/docker-compose.yml` brings up
+RabbitMQ, Postgres, and the worker container in one network.
+
+Health check: `GET /api/healthcheck` returns `{"status": "OK"}`.
+
+## Queueing a document
+
+`POST /ingest` accepts the same JSON payload as the backend `/ingest` route.
+`course_name` is required; provide the document as `s3_paths`, `url`, or
+`content`.
+
+```bash
+curl -X POST "http://<bridge-host>:8001/ingest" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $INGEST_API_KEY" \
+  -d '{
+    "course_name": "my-course",
+    "readable_filename": "lecture-01.pdf",
+    "s3_paths": "courses/my-course/lecture-01.pdf"
+  }'
+```
+
+A successful call returns the queued task id:
+
+```json
+{ "outcome": "Queued Ingest task", "task_id": "..." }
+```
+
+Common payload fields:
+
+| Field | Notes |
+| --- | --- |
+| `course_name` | Required. The course/project to ingest into. |
+| `readable_filename` | Display name shown in the course's documents view. Defaults to empty. |
+| `s3_paths` | A single S3 key (string) or a list of keys, in the bucket the course's connection config points at. |
+| `url` / `base_url` | For web documents (this is what Crawlee sends). |
+| `content` | Raw text content to ingest directly. |
+| `groups` | Optional document groups to attach. |
+
+## Bulk ingest pattern
+
+For a large corpus, loop over your S3 keys and POST one job per document. The
+bridge only *queues* work — each request is fast — and the worker paces itself
+via RabbitMQ prefetch, so it is safe to enqueue thousands of jobs up front:
+
+```bash
+aws s3 ls "s3://my-bucket/courses/my-course/" --recursive \
+  | awk '{print $4}' \
+  | while read -r key; do
+      curl -s -X POST "http://<bridge-host>:8001/ingest" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $INGEST_API_KEY" \
+        -d "{\"course_name\": \"my-course\", \"readable_filename\": \"$(basename "$key")\", \"s3_paths\": \"$key\"}"
+    done
+```
+
+Track progress via the `documents_in_progress` table (rows are removed as jobs
+complete) or the course's documents view in the frontend. Failed jobs land in
+the `documents_failed` table with the error message from the worker, including
+timeouts and crashes from the per-document subprocess watchdog.


### PR DESCRIPTION
Closes #118. Ported from ai-ta-backend#503 (that PR's branch also carried unrelated pgvector-migration commits; only the ingest-hardening work is here).

## Problems

1. **The worker process died on heavy or faulty PDFs.** `process_job` ran `main_ingest` (including OCR) synchronously on the RabbitMQ consumer thread. Observed on Fargate: native segfaults in the PDF/OCR libraries killed the whole worker (task exit 139), and long OCR blocked pika heartbeats and starved the Flask `/api/healthcheck`, so the ALB killed the task (exit 137). The redelivered message was then mislabeled by the redelivery guard as `worker crashed (e.g. ran out of memory)`.
2. **Enqueueing ingest jobs required the full Flask backend** — no lightweight HTTP path to the RabbitMQ ingest queue for external producers (Crawlee, migration scripts).

## Changes

- **`worker.py`** — run each document's `main_ingest` in a **spawned, time-boxed subprocess** (`run_ingest_isolated`; `INGEST_SUBPROCESS_TIMEOUT`, default 300s):
  - the consumer thread stays responsive (heartbeats + ALB healthcheck) during long OCR;
  - a native segfault kills only the child; the parent records `killed by signal N` in `documents_failed` and acks;
  - a hung/oversized OCR is killed at the watchdog limit with a clear timeout error — no requeue, so the redelivery guard can no longer mislabel these;
  - spawn (not fork) because the worker is multithreaded; AMQP heartbeat raised to `max(900, 3×timeout)` so the broker doesn't drop the connection mid-wait.
- **`bridge.py` (new)** — minimal Flask HTTP → RabbitMQ bridge: single `POST /ingest` route that mirrors the backend's payload and reuses `rmqueue.Queue.addJobToIngestQueue` (plus `/api/healthcheck`). Optional bearer auth via `INGEST_API_KEY`. Runs from the same image as the worker via a command override (`python bridge.py`).

## Adaptations for this repo

- The third problem in #118 — scanned/image-only PDFs crashing `_ocr_pdf` on a missing `force_embeddings` arg — **is already fixed here** (`ingest.py:1367` passes it), so no ingest.py change is included.
- The child subprocess **re-resolves its project connections** instead of inheriting them. This repo's `process_job` passes `_resolved_connections=resolved` into `main_ingest`, and `ResolvedConnections` holds live SQLAlchemy engines and Qdrant/boto3 clients — none of which survive pickling across a `spawn` boundary. Cost is one extra `project_external_connections` lookup per document.
- The failure record is written via `status_db` (the project's documents DB) rather than the host-bound `self.sql_session`, matching how the surrounding code in this repo routes ingest status rows.
- Dropped the now-unused module-level `from ingest import Ingest` in the parent.

## Validated in production (CropWizard pgvector re-ingest, ~512k docs)

- Pre-fix: repeated worker deaths on a set of large scanned PDFs (exit 137/139), each taking down in-flight work.
- Post-fix: **zero worker deaths**; the same PDFs either ingested (OCR now works), failed cleanly with `killed by signal 11`, or hit the watchdog — and two watchdog cases ingested successfully after a one-off `INGEST_SUBPROCESS_TIMEOUT=1800` run.
- The bridge served the full migration (both the S3-phase submitter and the Crawlee scraper POST to it) behind an ALB with bearer auth.

## Still fails (out of scope)

- Genuinely corrupt/unopenable PDFs ("cannot open broken document", PDFium load failures) — now fail cleanly per document.
- The worker dedup-replace deletes existing content before re-ingesting a duplicate; a failure after that delete loses the original (pre-existing design flaw, not addressed here).
