### PR TITLE
Reword country-of-concern notice

### DIFF
--- a/apps/frontend/src/components/Chat/ChatInput.tsx
+++ b/apps/frontend/src/components/Chat/ChatInput.tsx
@@ -963,7 +963,7 @@ export const ChatInput = ({
                   </span>
                   <div className="mb-1 flex items-center gap-2 text-base font-semibold">
                     <span aria-hidden="true">🌐</span>
-                    LLM from Country of Concern
+                    LLM from Country of Concern ({country})
                   </div>
                   <p className="text-sm leading-snug">
                     {getCountryOfConcernBannerLede(country, cocLocallyHosted)}{' '}

--- a/apps/frontend/src/utils/modelProviders/__tests__/countriesOfConcern.test.ts
+++ b/apps/frontend/src/utils/modelProviders/__tests__/countriesOfConcern.test.ts
@@ -118,7 +118,7 @@ describe('getCountryOfConcernBannerLede', () => {
   it('only claims local hosting when the model is locally hosted', () => {
     const local = getCountryOfConcernBannerLede(CountryOfConcern.China, true)
     expect(local).toContain('hosted locally at the U of I')
-    expect(local).toContain('China')
+    expect(local).toContain('does not send your conversation to external')
   })
 
   it('warns that data leaves the university for third-party-served models', () => {

--- a/apps/frontend/src/utils/modelProviders/countriesOfConcern.ts
+++ b/apps/frontend/src/utils/modelProviders/countriesOfConcern.ts
@@ -303,14 +303,14 @@ export function getCountryOfConcernBannerLede(
   if (locallyHosted) {
     return (
       `This model is hosted locally at the U of I, so Illinois Chat does not ` +
-      `send your conversation to servers in ${country}. Users should still be ` +
+      `send your conversation to external servers. Users should still be ` +
       `aware that the model itself was initially developed in a country deemed ` +
-      `worthy of extra caution in the AI space.`
+      `worthy of extra caution.`
     )
   }
   return (
     `This model was developed in ${country}, a country deemed worthy of extra ` +
-    `caution in the AI space, and it is served by a third-party provider rather ` +
+    `caution, and it is served by a third-party provider rather ` +
     `than hosted locally at the U of I. Your conversation leaves university ` +
     `infrastructure when you use this model, so please avoid sharing sensitive ` +
     `information.`


### PR DESCRIPTION
## Summary
Wording tweaks to the "LLM from Country of Concern" notice.

<img width="857" height="288" alt="image" src="https://github.com/user-attachments/assets/8c3ae5e0-8d4a-4e50-9597-f6f72b9a8e22" />


- Locally-hosted variant: "...does not send your conversation to **external servers**" (was "servers in {country}")
- Notice heading now includes the country: `LLM from Country of Concern ({country})`
- Removed "in the AI space" from both the locally-hosted and third-party variants

## Testing
`countriesOfConcern.test.ts` — 37 passed (assertion updated to match the new local-variant copy, which no longer names the country in the body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)