### PR TITLE
Update Cropwizard routing and references to cropwizard-2.0

### DIFF
--- a/apps/frontend/src/components/Chat/Chat.tsx
+++ b/apps/frontend/src/components/Chat/Chat.tsx
@@ -1813,7 +1813,7 @@ export const Chat = memo(
             <h4
               className={`text-md mb-2 text-[--welcome-foreground] ${montserrat_paragraph.variable} font-montserratParagraph`}
             >
-              {getCurrentPageName() === 'cropwizard-1.5' && (
+              {getCurrentPageName() === 'cropwizard-2.0' && (
                 <CropwizardLicenseDisclaimer />
               )}
               {getCurrentPageName() !== 'chat' && (

--- a/apps/frontend/src/components/Chat/__tests__/Chat.test.tsx
+++ b/apps/frontend/src/components/Chat/__tests__/Chat.test.tsx
@@ -2066,9 +2066,9 @@ describe('Chat component', () => {
   // ==========================================================================
 
   describe('cropwizard page', () => {
-    it('renders CropwizardLicenseDisclaimer on cropwizard-1.5 page', async () => {
+    it('renders CropwizardLicenseDisclaimer on cropwizard-2.0 page', async () => {
       globalThis.__TEST_ROUTER__ = {
-        asPath: '/cropwizard-1.5/chat',
+        asPath: '/cropwizard-2.0/chat',
         push: vi.fn(),
       }
 
@@ -2084,7 +2084,7 @@ describe('Chat component', () => {
         <Chat
           stopConversationRef={{ current: false }}
           courseMetadata={baseCourseMetadata}
-          courseName="cropwizard-1.5"
+          courseName="cropwizard-2.0"
           currentEmail="me@example.com"
           documentExists={false}
         />,

--- a/apps/frontend/src/pages/[course_name]/chat.tsx
+++ b/apps/frontend/src/pages/[course_name]/chat.tsx
@@ -61,11 +61,14 @@ const ChatPage: NextPage = () => {
 
       // Special case: Cropwizard redirect
       if (
-        ['cropwizard', 'cropwizard-1.0', 'cropwizard-1'].includes(
-          courseName.toLowerCase(),
-        )
+        [
+          'cropwizard',
+          'cropwizard-1.0',
+          'cropwizard-1',
+          'cropwizard-1.5',
+        ].includes(courseName.toLowerCase())
       ) {
-        await router.push(`/cropwizard-1.5`)
+        await router.push(`/cropwizard-2.0`)
       }
 
       // Fetch course metadata

--- a/apps/frontend/src/pages/index.tsx
+++ b/apps/frontend/src/pages/index.tsx
@@ -974,7 +974,7 @@ function FlagshipChatbots() {
         "Using all of Clowder's documentation, this bot will answer questions and point you to the right docs and YouTube videos about Clowder.",
     },
     {
-      course_slug: 'cropwizard-1.5',
+      course_slug: 'cropwizard-2.0',
       imageSrc: '/media/hero_courses_banners/aifarms_wide_logo.png',
       title: 'Crop Wizard',
       badge: 'AIFARMS',


### PR DESCRIPTION
Closes #126

## Why

The Cropwizard corpus in the `cropwizard-pgvector` Supabase project was migrated from `course_name = cropwizard-1.5` to `cropwizard-2.0` across every table carrying the column (`documents`, `embeddings`, `doc_groups`, `documents_failed`, `documents_in_progress`). The frontend still routed to and gated on the old slug, which no longer has any documents or embeddings behind it.

This PR is deliberately scoped to Cropwizard routing and slug references only — no data or schema changes.

## Changes

- **`pages/index.tsx`** — homepage flagship card `course_slug` now points at `cropwizard-2.0`.
- **`pages/[course_name]/chat.tsx`** — the legacy-alias redirect now targets `/cropwizard-2.0`, and `cropwizard-1.5` joins the alias list (`cropwizard`, `cropwizard-1.0`, `cropwizard-1`) so existing links and bookmarks keep resolving instead of landing on an empty course.
- **`components/Chat/Chat.tsx`** — `CropwizardLicenseDisclaimer` is gated on `cropwizard-2.0`, so the license notice still renders on the live course.
- **`components/Chat/__tests__/Chat.test.tsx`** — the disclaimer test follows the gate.

## Intentionally left alone

- `utils/projectConnections/__tests__/tester.test.ts` — the mention is a comment describing a stored Qdrant *connection* record, unrelated to course routing.
- `ai_ta_backend/utils/migrate_qdrant_hosting.py` — commented-out historical migration code.

Neither file was reformatted; both `Chat.tsx` and `chat.tsx` are already non-prettier-clean on `main`, and running `--write` would have buried this diff in unrelated churn. The new hunk itself was verified against the project's prettier config.

## Testing

`npx vitest run src/components/Chat/__tests__/Chat.test.tsx` — 43/43 passing.