### PR TITLE
fix(ci): pass missing NEXT_PUBLIC build args to the frontend image

### DIFF
--- a/.github/workflows/illinois-chat-dev.yml
+++ b/.github/workflows/illinois-chat-dev.yml
@@ -90,14 +90,30 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.POSTHOG_API_KEY }}
           NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+          NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG: ${{ vars.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG || 'True' }}
+          NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT: ${{ vars.NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT }}
         run: |
           cd apps/frontend
+
+          # See release-images.yml: NEXT_PUBLIC_* is baked in at build time and cannot be
+          # fixed at runtime, so an empty or slash-less Keycloak URL must fail the build.
+          if [ -z "$NEXT_PUBLIC_KEYCLOAK_URL" ]; then
+            echo "::error::NEXT_PUBLIC_KEYCLOAK_URL is empty; JWT issuer would fall back to the Host header."
+            exit 1
+          fi
+          case "$NEXT_PUBLIC_KEYCLOAK_URL" in
+            */) ;;
+            *) echo "::error::NEXT_PUBLIC_KEYCLOAK_URL must end with a trailing slash."; exit 1 ;;
+          esac
+
           docker build --platform=linux/amd64 -f Dockerfile \
             --build-arg NEXT_PUBLIC_KEYCLOAK_URL="$NEXT_PUBLIC_KEYCLOAK_URL" \
             --build-arg NEXT_PUBLIC_KEYCLOAK_REALM="$NEXT_PUBLIC_KEYCLOAK_REALM" \
             --build-arg NEXT_PUBLIC_KEYCLOAK_CLIENT_ID="$NEXT_PUBLIC_KEYCLOAK_CLIENT_ID" \
             --build-arg NEXT_PUBLIC_POSTHOG_KEY="$NEXT_PUBLIC_POSTHOG_KEY" \
             --build-arg NEXT_PUBLIC_POSTHOG_HOST="$NEXT_PUBLIC_POSTHOG_HOST" \
+            --build-arg NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG="$NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG" \
+            --build-arg NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT="$NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT" \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:main \

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -84,14 +84,38 @@ jobs:
           NEXT_PUBLIC_KEYCLOAK_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID }}
           NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.PROD_POSTHOG_API_KEY }}
           NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.PROD_NEXT_PUBLIC_POSTHOG_HOST }}
+          NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG: ${{ vars.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG || 'True' }}
+          NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT: ${{ vars.NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT }}
         run: |
           cd apps/frontend
+
+          # NEXT_PUBLIC_* values are inlined by Next.js at BUILD time, including into
+          # server-side code. A missing or malformed value here cannot be corrected by
+          # runtime env vars — it ships baked into the image. Fail loudly instead.
+          if [ -z "$NEXT_PUBLIC_KEYCLOAK_URL" ]; then
+            echo "::error::PROD_NEXT_PUBLIC_KEYCLOAK_URL is empty. The server would fall back to"
+            echo "::error::deriving the JWT issuer from the request Host header, which fails token"
+            echo "::error::verification behind a load balancer (401 'Invalid token' on every API call)."
+            exit 1
+          fi
+          case "$NEXT_PUBLIC_KEYCLOAK_URL" in
+            */) ;;
+            *)
+              echo "::error::PROD_NEXT_PUBLIC_KEYCLOAK_URL must end with a trailing slash."
+              echo "::error::The app builds URLs as \${KEYCLOAK_URL}realms/\${REALM}, so a missing"
+              echo "::error::slash produces an invalid issuer and JWKS endpoint."
+              exit 1
+              ;;
+          esac
+
           docker build \
             --build-arg NEXT_PUBLIC_KEYCLOAK_URL="$NEXT_PUBLIC_KEYCLOAK_URL" \
             --build-arg NEXT_PUBLIC_KEYCLOAK_REALM="$NEXT_PUBLIC_KEYCLOAK_REALM" \
             --build-arg NEXT_PUBLIC_KEYCLOAK_CLIENT_ID="$NEXT_PUBLIC_KEYCLOAK_CLIENT_ID" \
             --build-arg NEXT_PUBLIC_POSTHOG_KEY="$NEXT_PUBLIC_POSTHOG_KEY" \
             --build-arg NEXT_PUBLIC_POSTHOG_HOST="$NEXT_PUBLIC_POSTHOG_HOST" \
+            --build-arg NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG="$NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG" \
+            --build-arg NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT="$NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT" \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
 
       - name: Push frontend image

--- a/apps/frontend/src/components/UIUC-Components/N8NPage.tsx
+++ b/apps/frontend/src/components/UIUC-Components/N8NPage.tsx
@@ -59,7 +59,9 @@ const MakeToolsPage = ({ course_name }: { course_name: string }) => {
   const auth = useAuth()
 
   const useIllinoisChatConfig = useMemo(() => {
-    return process.env.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG === 'True'
+    return (
+      process.env.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG?.toLowerCase() === 'true'
+    )
   }, [])
 
   const [courseMetadata, setCourseMetadata] = useState<CourseMetadata | null>(

--- a/apps/frontend/src/pages/index.tsx
+++ b/apps/frontend/src/pages/index.tsx
@@ -129,7 +129,9 @@ const TypingAnimation: React.FC = () => {
 const Home: NextPage = () => {
   const [isTooltipVisible, setIsTooltipVisible] = useState(false)
   const useIllinoisChatConfig = useMemo(() => {
-    return process.env.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG === 'True'
+    return (
+      process.env.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG?.toLowerCase() === 'true'
+    )
   }, [])
   const IllinoisChatBannerContent = useMemo(() => {
     return process.env.NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT || null

--- a/apps/frontend/src/providers/KeycloakProvider.tsx
+++ b/apps/frontend/src/providers/KeycloakProvider.tsx
@@ -74,7 +74,8 @@ export const KeycloakProvider = ({ children }: AuthProviderProps) => {
         // Extra logic: if root path and Illinois Chat config enabled → go to /chat
         if (
           redirectPath === '/' &&
-          process.env.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG === 'True'
+          process.env.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG?.toLowerCase() ===
+            'true'
         ) {
           redirectPath = '/chat'
         }


### PR DESCRIPTION
Note:

1. I have created `NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG` and set to `True`
2. Updated the `PROD_NEXT_PUBLIC_KEYCLOAK_URL` to `https://chat.illinois.edu/keycloak/`
3. Leave the `NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT` out (doesn't exist as a Github secret yet)

---


## What broke

`apps/frontend/Dockerfile` declares `ARG NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG` and `ARG NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT`, but neither monorepo workflow passes them to `docker build`. The pre-monorepo workflow (`apps/frontend/.github/workflows/build-and-push-on-tag.yml:52`, now dead) did.

`NEXT_PUBLIC_*` is inlined by Next.js at **build** time, including into server-side code, so both baked into the prod image as empty strings. Nothing set on the running task can override that.

That is the direct cause of the prod log spam:

```
Using UIUC Chat config: use raw SQL to fetch user data from keycloak.user_entity.
PostgresError: relation "keycloak.user_entity" does not exist
    at validateApiKeyAndRetrieveData (/app/.next/server/chunks/7573.js:1:1142)
```

With the flag empty, `validateApiKeyAndRetrieveData` takes the UIUC-chat branch and queries `keycloak.user_entity` in the *application* database. Keycloak has its own database on this deployment, so the table isn't there. This affects the API-key endpoint only — it is not the cause of the browser 401s.

## The 401s (related, same root cause class)

`PROD_NEXT_PUBLIC_KEYCLOAK_URL` was created **2026-08-13 21:15Z**, after the build that produced the running image. So `NEXT_PUBLIC_KEYCLOAK_URL` is empty in that image, and `getKeycloakIssuerUrl` falls through to `https://${hostname}/keycloak/realms/${realm}` using the pod's `Host`/`x-forwarded-host` header. Behind the ALB that doesn't match the token's `iss` (`https://chat.illinois.edu/keycloak/realms/illinois_chat_realm`), so `jwt.verify` throws `JsonWebTokenError` and every authenticated call gets the 401 `"Invalid token"` from `authMiddleware.ts:66`. Browser login is unaffected because the client never validates the issuer.

This PR doesn't change that resolution logic — it makes the build **fail loudly** instead of shipping a broken image.

## Changes

- Pass `NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG` (defaulting to `True`) and `NEXT_PUBLIC_ILLINOIS_CHAT_BANNER_CONTENT` in both `release-images.yml` and `illinois-chat-dev.yml`.
- Fail the build if `NEXT_PUBLIC_KEYCLOAK_URL` is empty or missing its trailing slash — the code concatenates `${url}realms/${realm}`, so a missing slash yields an invalid issuer *and* JWKS URI.
- Normalize the flag check: three call sites compared `=== 'True'` while `validate.ts` lowercased first, so a value of `"true"` would have half-applied.

## Required before this helps — repo settings

Secret values can't be read back, so please confirm by hand in Settings → Secrets and variables → Actions:

| name | kind | required value |
|---|---|---|
| `PROD_NEXT_PUBLIC_KEYCLOAK_URL` | secret | `https://chat.illinois.edu/keycloak/` — **trailing slash required** |
| `NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG` | variable | `True` (optional; the workflow now defaults to `True`) |

Heads up: `gh variable list` returns **empty** for this repo, so every `vars.*` reference currently resolves to nothing. `NEXT_PUBLIC_KEYCLOAK_REALM` and `NEXT_PUBLIC_KEYCLOAK_CLIENT_ID` are read from `secrets.*` and do exist, so those are fine.

## Verifying a built image

`NEXT_PUBLIC_*` won't show up in `printenv` at runtime — it's compiled in. Check the bundle:

```bash
grep -ro 'https://[a-z0-9.-]*/keycloak/realms/[a-z_]*' /app/.next/server | sort -u
```

Should print exactly `https://chat.illinois.edu/keycloak/realms/illinois_chat_realm`.

## Testing

`npx vitest run` over the affected areas: 55 files, 493 tests, all passing.

## Not included

Runtime issuer resolution is still build-time-only. A follow-up worth doing: accept a `KEYCLOAK_ISSUER_URL` runtime env var, tolerate a missing trailing slash, and log expected-vs-actual issuer on verification failure. That last one alone would have turned this outage into a two-minute diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
