### PR TITLE
130 properly fix the gh trunk test

### DIFF
--- a/.github/workflows/illinois-chat-dev.yml
+++ b/.github/workflows/illinois-chat-dev.yml
@@ -9,6 +9,10 @@ on:
       - 'infra/**'
       - '.github/workflows/**'
 
+permissions:
+  contents: read
+  checks: write # trunk-action posts lint results as check-run annotations
+
 jobs:
   deploy-dev:
     runs-on: ubuntu-latest
@@ -23,10 +27,15 @@ jobs:
         run: |
           npm ci
 
-      - name: Install Trunk
+      # Lint only the commits in this push (github.event.before..after), not
+      # the whole tree -- main carries ~895 pre-existing issues from before it
+      # was linted, and check-mode: all would fail on all of them forever.
+      # These commits already passed the same linters as a PR diff, so this is
+      # a cheap guard against anything that lands on main outside a PR.
+      - name: Trunk Check (pushed commits only)
         uses: trunk-io/trunk-action@v1
         with:
-          check-mode: none
+          check-mode: push
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/illinois-chat-dev.yml
+++ b/.github/workflows/illinois-chat-dev.yml
@@ -9,9 +9,11 @@ on:
       - 'infra/**'
       - '.github/workflows/**'
 
+# check-mode: push runs trunk without --github-annotate, so it needs no
+# write scope -- results surface via the step's exit code. Declaring the
+# block at all also drops every unlisted scope to none.
 permissions:
   contents: read
-  checks: write # trunk-action posts lint results as check-run annotations
 
 jobs:
   deploy-dev:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,26 +25,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Matches illinois-chat-dev.yml (push to main), which also uses
-      # check-mode: none. Trunk is installed but runs no checks.
+      # Lint only what this PR changed, by diffing against the PR base sha.
+      # check-mode: all would point trunk at the whole accumulated tree
+      # (~1436 files, ~895 pre-existing issues, since main was never linted)
+      # and attribute every one of them to whichever PR happened to be open.
       #
-      # Why: main has never been linted -- the only workflow that runs on
-      # pushes to main sets check-mode: none -- so violations accumulated
-      # freely. check-mode: all here pointed trunk at the whole accumulated
-      # tree (1436 files, 895 issues) and attributed every pre-existing issue
-      # to whichever PR happened to be open, so every PR failed regardless of
-      # its contents.
-      #
-      # This is a stopgap that unblocks PRs by making both workflows agree.
-      # It does mean no lint coverage anywhere. See #86 for the real fix
-      # (check-mode: pull_request so PRs lint only their own diff, plus a
-      # .trunk/trunk.yaml exclusion for apps/frontend, whose prettier.config.cjs
-      # requires prettier-plugin-tailwindcss that trunk's hermetic prettier
-      # cannot resolve).
-      - name: Install Trunk
+      # fetch-depth: 0 above is required -- trunk needs the base commit
+      # present locally to compute the diff.
+      - name: Trunk Check (PR diff only)
         uses: trunk-io/trunk-action@v1
         with:
-          check-mode: none
+          check-mode: pull_request
 
       # Backend tests placeholder
       - name: Backend tests

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -4,9 +4,11 @@ on:
   release:
     types: [published]
 
+# check-mode: all runs trunk without --github-annotate, so it needs no
+# write scope -- results surface via the step's exit code. Declaring the
+# block at all also drops every unlisted scope to none.
 permissions:
   contents: read
-  checks: write # trunk-action posts lint results as check-run annotations
 
 jobs:
   build-and-push-release:

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  checks: write # trunk-action posts lint results as check-run annotations
+
 jobs:
   build-and-push-release:
     runs-on: ubuntu-latest
@@ -13,20 +17,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # check-mode: none, matching pr-checks.yml and illinois-chat-dev.yml.
-      #
-      # Why: main has never been linted, so check-mode: all points trunk at
-      # the whole accumulated tree (1436 files, 895 issues) and fails. Here
-      # that failure would block a published release from building and
-      # pushing its images, for reasons unrelated to the release.
-      #
-      # Part of the same stopgap; see #86 for the real fix (check-mode:
-      # pull_request on PRs, plus a .trunk/trunk.yaml exclusion for
-      # apps/frontend).
-      - name: Install Trunk
+      # A `release: published` event has no diff to lint against, so the only
+      # meaningful mode here is `all` -- a full-tree scan. That still reports
+      # main's ~895 pre-existing issues, so it is advisory only: a lint failure
+      # must never stop a published release from building and pushing images.
+      # The blocking gates are pr-checks.yml (PR diff) and illinois-chat-dev.yml
+      # (pushed commits). Drop continue-on-error once the backlog is cleared.
+      - name: Trunk Check (full tree, advisory)
+        continue-on-error: true
         uses: trunk-io/trunk-action@v1
         with:
-          check-mode: none
+          check-mode: all
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -52,6 +52,12 @@ lint:
     - linters: [prettier]
       paths:
         - apps/frontend/**
+    # Checked-in GitBook screenshots. oxipng rewrites all ~49 of them, which
+    # is pure binary churn in any PR that happens to touch the docs tree and
+    # tells us nothing about code quality.
+    - linters: [oxipng]
+      paths:
+        - "**/.gitbook/assets/**"
 actions:
   enabled:
     - trunk-announce


### PR DESCRIPTION
## Summary

Re-enables Trunk linting in CI. All three workflows had `check-mode: none`, which installed Trunk but ran no checks, so nothing in this repo was being linted anywhere. This replaces that blanket disable with the check mode appropriate to each workflow's trigger.

## Changes

| Workflow | Trigger | Mode | Scope |
|---|---|---|---|
| `pr-checks.yml` | `pull_request` | `pull_request` | PR diff vs base SHA — blocking |
| `illinois-chat-dev.yml` | `push` to main | `push` | commits in that push — blocking |
| `release-images.yml` | `release: published` | `all` + `continue-on-error` | full tree — advisory only |

A `release` event has no diff to compare against, so a full-tree scan is the only meaningful mode there. It's non-blocking by design: a lint failure must never stop a published release from building and pushing its images.

Also in this PR:

- **Explicit `permissions:` blocks** on the two push-triggered workflows, which previously declared none and silently inherited the repo default. Both are `contents: read`. Only `pr-checks.yml` gets `checks: write`, since `pull_request` is the only mode that invokes Trunk with `--github-annotate` and needs the Checks API to post inline annotations.
- **`oxipng` exclusion for `**/.gitbook/assets/**`** it rewrites ~49 checked-in documentation screenshots, which is binary churn in any PR  touching the docs tree and says nothing about code quality.