### PR TITLE
135 model selection dropdown list gets cut off on smaller viewportswindow sizes

### DIFF
--- a/apps/frontend/src/components/Chat/ModelSelect.tsx
+++ b/apps/frontend/src/components/Chat/ModelSelect.tsx
@@ -57,6 +57,8 @@ interface ModelDropdownProps {
 
 const MODEL_DROPDOWN_MAX_CAP_PX = 480
 const MODEL_DROPDOWN_PADDING_PX = 8
+/** Roughly three model rows: below this the list is unusable, so let the modal scroll instead. */
+const MODEL_DROPDOWN_MIN_PX = 160
 
 /** Keep the model list inside the settings modal (or viewport fallback) so it can scroll instead of overflowing. */
 export function getModelDropdownMaxHeight({
@@ -64,16 +66,40 @@ export function getModelDropdownMaxHeight({
   containerRect,
   padding = MODEL_DROPDOWN_PADDING_PX,
   cap = MODEL_DROPDOWN_MAX_CAP_PX,
+  floor = MODEL_DROPDOWN_MIN_PX,
 }: {
   triggerRect: Pick<DOMRect, 'top' | 'bottom'>
   containerRect: Pick<DOMRect, 'top' | 'bottom'>
   padding?: number
   cap?: number
+  floor?: number
 }): number {
   const spaceBelow = containerRect.bottom - triggerRect.bottom - padding
   const spaceAbove = triggerRect.top - containerRect.top - padding
   const available = Math.max(spaceBelow, spaceAbove)
-  return Math.max(0, Math.min(cap, available))
+  // A container too short for `floor` gets `floor` anyway; the modal's own overflow clips it.
+  return Math.min(cap, Math.max(Math.min(floor, cap), available))
+}
+
+/**
+ * Mantine passes `maxDropdownHeight` through `rem()`, which divides by a hardcoded 16 —
+ * so a raw pixel value renders as `px/16rem` and grows with the user's root font size.
+ * Pre-scale it so the emitted rem resolves back to the pixel height we measured.
+ */
+export function toRemScaledDropdownHeight(
+  pxHeight: number,
+  rootFontSizePx: number,
+): number {
+  const rootFontSize = rootFontSizePx > 0 ? rootFontSizePx : 16
+  return (pxHeight * 16) / rootFontSize
+}
+
+function getRootFontSizePx(): number {
+  if (typeof window === 'undefined') return 16
+  const parsed = Number.parseFloat(
+    window.getComputedStyle(document.documentElement).fontSize,
+  )
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 16
 }
 
 export function getModelDropdownBoundaryRect(
@@ -233,6 +259,7 @@ export const ModelItem = forwardRef<
                   multiline
                   width={280}
                   withArrow
+                  withinPortal
                   label={getCountryOfConcernShortMessage(countryOfConcern)}
                 >
                   <span
@@ -395,27 +422,49 @@ const ModelDropdown: React.FC<
         ? window.innerHeight
         : MODEL_DROPDOWN_MAX_CAP_PX)
 
-    if (!triggerEl) {
-      setMaxDropdownHeight(
-        Math.min(
+    const availablePx = triggerEl
+      ? getModelDropdownMaxHeight({
+          triggerRect: triggerEl.getBoundingClientRect(),
+          containerRect: getModelDropdownBoundaryRect(triggerEl),
+        })
+      : Math.min(
           MODEL_DROPDOWN_MAX_CAP_PX,
-          Math.max(0, measuredViewportHeight - 200),
-        ),
-      )
-      return
-    }
+          Math.max(MODEL_DROPDOWN_MIN_PX, measuredViewportHeight - 200),
+        )
 
     setMaxDropdownHeight(
-      getModelDropdownMaxHeight({
-        triggerRect: triggerEl.getBoundingClientRect(),
-        containerRect: getModelDropdownBoundaryRect(triggerEl),
-      }),
+      toRemScaledDropdownHeight(availablePx, getRootFontSizePx()),
     )
   }, [viewportHeight])
 
   useEffect(() => {
     if (dropdownOpened) {
       constrainDropdownHeight()
+    }
+  }, [constrainDropdownHeight, dropdownOpened])
+
+  // The modal body is its own scroll container, so scrolling it moves the (non-portalled)
+  // dropdown without changing the viewport size. Re-measure instead of keeping a stale height.
+  useEffect(() => {
+    if (!dropdownOpened || typeof window === 'undefined') return
+
+    let frame: number | null = null
+    const handleReposition = () => {
+      if (frame !== null) return
+      frame = window.requestAnimationFrame(() => {
+        frame = null
+        constrainDropdownHeight()
+      })
+    }
+
+    // Capture phase so inner scroll containers, not just the window, are observed.
+    window.addEventListener('scroll', handleReposition, true)
+    window.addEventListener('resize', handleReposition)
+
+    return () => {
+      if (frame !== null) window.cancelAnimationFrame(frame)
+      window.removeEventListener('scroll', handleReposition, true)
+      window.removeEventListener('resize', handleReposition)
     }
   }, [constrainDropdownHeight, dropdownOpened])
 
@@ -538,7 +587,6 @@ const ModelDropdown: React.FC<
           maxDropdownHeight={maxDropdownHeight}
           zIndex={400}
           positionDependencies={[maxDropdownHeight]}
-          switchDirectionOnFlip
           rightSectionWidth="auto"
           icon={
             selectedModel ? (
@@ -560,6 +608,7 @@ const ModelDropdown: React.FC<
                   multiline
                   width={280}
                   withArrow
+                  withinPortal
                   label={getCountryOfConcernShortMessage(selectedModelCountry)}
                 >
                   <span

--- a/apps/frontend/src/components/Chat/ModelSelect.tsx
+++ b/apps/frontend/src/components/Chat/ModelSelect.tsx
@@ -7,8 +7,15 @@ import {
   IconAlertTriangle,
   IconInfoCircle,
 } from '@tabler/icons-react'
-import { forwardRef, useContext, useEffect, useState } from 'react'
-import { useMediaQuery } from '@mantine/hooks'
+import {
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import { useMediaQuery, useViewportSize } from '@mantine/hooks'
 import HomeContext from '~/pages/api/home/home.context'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import { Group, Select, Title, Text, ActionIcon, Tooltip } from '@mantine/core'
@@ -46,6 +53,49 @@ interface ModelDropdownProps {
   isWebLLM?: boolean
   loadingModelId: string | null
   chat_ui: ChatUI
+}
+
+const MODEL_DROPDOWN_MAX_CAP_PX = 480
+const MODEL_DROPDOWN_PADDING_PX = 8
+
+/** Keep the model list inside the settings modal (or viewport fallback) so it can scroll instead of overflowing. */
+export function getModelDropdownMaxHeight({
+  triggerRect,
+  containerRect,
+  padding = MODEL_DROPDOWN_PADDING_PX,
+  cap = MODEL_DROPDOWN_MAX_CAP_PX,
+}: {
+  triggerRect: Pick<DOMRect, 'top' | 'bottom'>
+  containerRect: Pick<DOMRect, 'top' | 'bottom'>
+  padding?: number
+  cap?: number
+}): number {
+  const spaceBelow = containerRect.bottom - triggerRect.bottom - padding
+  const spaceAbove = triggerRect.top - containerRect.top - padding
+  const available = Math.max(spaceBelow, spaceAbove)
+  return Math.max(0, Math.min(cap, available))
+}
+
+export function getModelDropdownBoundaryRect(
+  triggerEl: HTMLElement,
+): Pick<DOMRect, 'top' | 'bottom'> {
+  const boundary =
+    triggerEl.closest('[data-settings-modal-body]') ||
+    triggerEl.closest('[data-settings-modal]') ||
+    triggerEl.closest('.mantine-Modal-content') ||
+    triggerEl.closest('[role="dialog"]')
+
+  if (boundary instanceof HTMLElement) {
+    return boundary.getBoundingClientRect()
+  }
+
+  return {
+    top: 0,
+    bottom:
+      typeof window !== 'undefined'
+        ? window.innerHeight
+        : MODEL_DROPDOWN_MAX_CAP_PX,
+  }
 }
 
 interface ModelItemProps extends React.ComponentPropsWithoutRef<'div'> {
@@ -329,7 +379,45 @@ const ModelDropdown: React.FC<
   setLoadingModelId,
   chat_ui,
 }) => {
-  const { state, dispatch: homeDispatch } = useContext(HomeContext)
+  const { state } = useContext(HomeContext)
+  const { height: viewportHeight } = useViewportSize()
+  const selectInputRef = useRef<HTMLInputElement>(null)
+  const [dropdownOpened, setDropdownOpened] = useState(false)
+  const [maxDropdownHeight, setMaxDropdownHeight] = useState(
+    MODEL_DROPDOWN_MAX_CAP_PX,
+  )
+
+  const constrainDropdownHeight = useCallback(() => {
+    const triggerEl = selectInputRef.current
+    const measuredViewportHeight =
+      viewportHeight ||
+      (typeof window !== 'undefined'
+        ? window.innerHeight
+        : MODEL_DROPDOWN_MAX_CAP_PX)
+
+    if (!triggerEl) {
+      setMaxDropdownHeight(
+        Math.min(
+          MODEL_DROPDOWN_MAX_CAP_PX,
+          Math.max(0, measuredViewportHeight - 200),
+        ),
+      )
+      return
+    }
+
+    setMaxDropdownHeight(
+      getModelDropdownMaxHeight({
+        triggerRect: triggerEl.getBoundingClientRect(),
+        containerRect: getModelDropdownBoundaryRect(triggerEl),
+      }),
+    )
+  }, [viewportHeight])
+
+  useEffect(() => {
+    if (dropdownOpened) {
+      constrainDropdownHeight()
+    }
+  }, [constrainDropdownHeight, dropdownOpened])
 
   // Filter out providers that are not enabled and their models which are disabled
   const { enabledProvidersAndModels, allModels } = Object.keys(
@@ -385,15 +473,21 @@ const ModelDropdown: React.FC<
 
       <div
         tabIndex={0}
-        className="relative mt-4 flex w-full flex-col items-start px-4"
+        className="relative mt-4 flex w-full flex-col items-start overflow-visible px-4"
       >
         <Select
-          className="menu z-[50] w-full"
+          ref={selectInputRef}
+          className="menu w-full"
           size="md"
           placeholder="Select a model"
           aria-label="Select a model"
           searchable
           value={value}
+          onDropdownOpen={() => {
+            setDropdownOpened(true)
+            constrainDropdownHeight()
+          }}
+          onDropdownClose={() => setDropdownOpened(false)}
           onChange={async (modelId) => {
             if (state.webLLMModelIdLoading.isLoading) {
               setLoadingModelId(modelId)
@@ -441,7 +535,10 @@ const ModelDropdown: React.FC<
               setLoadingModelId={setLoadingModelId}
             />
           )}
-          maxDropdownHeight={480}
+          maxDropdownHeight={maxDropdownHeight}
+          zIndex={400}
+          positionDependencies={[maxDropdownHeight]}
+          switchDirectionOnFlip
           rightSectionWidth="auto"
           icon={
             selectedModel ? (
@@ -525,7 +622,8 @@ const ModelDropdown: React.FC<
               boxShadow: theme.shadows.lg,
               width: '100%',
               maxWidth: '100%',
-              position: 'absolute',
+              overflowY: 'auto',
+              zIndex: 400,
             },
             item: {
               color: 'var(--modal-button-text)',
@@ -548,8 +646,8 @@ const ModelDropdown: React.FC<
               },
             },
           })}
-          dropdownPosition="bottom"
-          withinPortal
+          dropdownPosition="flip"
+          withinPortal={false}
         />
       </div>
     </>

--- a/apps/frontend/src/components/Chat/UserSettings.tsx
+++ b/apps/frontend/src/components/Chat/UserSettings.tsx
@@ -21,6 +21,9 @@ const useStyles = createStyles((theme) => ({
     borderRadius: '.25rem',
     color: 'var(--modal-text)',
     backgroundColor: 'var(--modal)',
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
   },
   modalHeader: {
     width: '100%',
@@ -107,7 +110,8 @@ export const UserSettings = () => {
         style={{ width: '100%', color: 'var(--background-faded)' }}
       />
       <Modal.Content
-        className={`${classes.modalContent} ${isSmallScreen ? 'p-2' : 'p-4'} overflow-x-hidden bg-[--modal] text-[--modal-text] md:rounded-lg`}
+        data-settings-modal
+        className={`${classes.modalContent} ${isSmallScreen ? 'p-2' : 'p-4'} overflow-hidden bg-[--modal] text-[--modal-text] md:rounded-lg`}
       >
         <Modal.Header className={classes.modalHeader}>
           <Modal.Title
@@ -121,7 +125,11 @@ export const UserSettings = () => {
             className="text-[--foreground-faded] hover:text-[--foreground]"
           />
         </Modal.Header>
-        <Modal.Body className="mt-4" p={isSmallScreen ? 'xs' : 'md'}>
+        <Modal.Body
+          data-settings-modal-body
+          className="mt-4 min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
+          p={isSmallScreen ? 'xs' : 'md'}
+        >
           <Tabs
             orientation="vertical"
             defaultValue="model"

--- a/apps/frontend/src/components/Chat/__tests__/ModelSelect.test.tsx
+++ b/apps/frontend/src/components/Chat/__tests__/ModelSelect.test.tsx
@@ -35,6 +35,60 @@ vi.mock('../UserSettings', () => ({
   modelCached: [],
 }))
 
+describe('getModelDropdownMaxHeight', () => {
+  it('uses remaining space below the trigger when that side is larger', async () => {
+    const { getModelDropdownMaxHeight } = await import('../ModelSelect')
+
+    expect(
+      getModelDropdownMaxHeight({
+        triggerRect: { top: 80, bottom: 120 },
+        containerRect: { top: 40, bottom: 500 },
+      }),
+    ).toBe(372)
+  })
+
+  it('uses remaining space above the trigger when that side is larger', async () => {
+    const { getModelDropdownMaxHeight } = await import('../ModelSelect')
+
+    expect(
+      getModelDropdownMaxHeight({
+        triggerRect: { top: 420, bottom: 460 },
+        containerRect: { top: 40, bottom: 500 },
+      }),
+    ).toBe(372)
+  })
+
+  it('stays inside a short modal instead of overflowing it', async () => {
+    const { getModelDropdownMaxHeight } = await import('../ModelSelect')
+
+    // Nest Hub-like: 600px viewport, modal shorter than the old 480px dropdown.
+    expect(
+      getModelDropdownMaxHeight({
+        triggerRect: { top: 180, bottom: 220 },
+        containerRect: { top: 40, bottom: 560 },
+      }),
+    ).toBe(332)
+
+    expect(
+      getModelDropdownMaxHeight({
+        triggerRect: { top: 150, bottom: 180 },
+        containerRect: { top: 100, bottom: 220 },
+      }),
+    ).toBe(42)
+  })
+
+  it('never exceeds the height cap', async () => {
+    const { getModelDropdownMaxHeight } = await import('../ModelSelect')
+
+    expect(
+      getModelDropdownMaxHeight({
+        triggerRect: { top: 40, bottom: 80 },
+        containerRect: { top: 0, bottom: 2000 },
+      }),
+    ).toBe(480)
+  })
+})
+
 describe('ModelSelect', () => {
   it('renders and toggles the details accordion', async () => {
     const user = userEvent.setup()
@@ -109,6 +163,100 @@ describe('ModelSelect', () => {
     expect(
       screen.getByText(/More details about the AI models/i),
     ).toBeInTheDocument()
+  })
+
+  it('opens a scrollable model list that stays inside the settings modal', async () => {
+    const user = userEvent.setup()
+    const { ModelSelect } = await import('../ModelSelect')
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+      function (this: HTMLElement) {
+        if (
+          this.hasAttribute?.('data-settings-modal') ||
+          this.hasAttribute?.('data-settings-modal-body')
+        ) {
+          return {
+            x: 0,
+            y: 40,
+            top: 40,
+            bottom: 520,
+            left: 0,
+            right: 800,
+            width: 800,
+            height: 480,
+            toJSON: () => ({}),
+          } as DOMRect
+        }
+        return {
+          x: 0,
+          y: 140,
+          top: 140,
+          bottom: 180,
+          left: 0,
+          right: 320,
+          width: 320,
+          height: 40,
+          toJSON: () => ({}),
+        } as DOMRect
+      },
+    )
+
+    const models = Array.from({ length: 20 }, (_, index) => ({
+      id: `model-${index}`,
+      name: `Model ${index}`,
+      tokenLimit: 128000,
+      enabled: true,
+    }))
+
+    renderWithProviders(
+      <div data-settings-modal-body>
+        <ModelSelect chat_ui={{} as any} />
+      </div>,
+      {
+        homeState: {
+          llmProviders: {
+            [ProviderNames.OpenAI]: {
+              provider: ProviderNames.OpenAI,
+              enabled: true,
+              models,
+            },
+          } as any,
+          defaultModelId: 'model-0' as any,
+          selectedConversation: {
+            id: 'c1',
+            name: 'Test',
+            messages: [],
+            model: {
+              id: 'model-0',
+              name: 'Model 0',
+              tokenLimit: 128000,
+              enabled: true,
+              provider: ProviderNames.OpenAI,
+            },
+            prompt: 'p',
+            temperature: 0.3,
+            folderId: null,
+          } as any,
+        },
+        homeContext: {
+          handleUpdateConversation: vi.fn(),
+        },
+      },
+    )
+
+    await user.click(screen.getByRole('searchbox', { name: /select a model/i }))
+
+    const listbox = await screen.findByRole('listbox')
+    expect(listbox).toBeInTheDocument()
+    expect(screen.getByText('Model 19')).toBeInTheDocument()
+
+    const constrained = listbox.closest('[style*="max-height"]') as HTMLElement
+    expect(constrained).toBeTruthy()
+    const maxHeightPx =
+      Number.parseFloat(constrained.style.maxHeight) *
+      (constrained.style.maxHeight.endsWith('rem') ? 16 : 1)
+    expect(maxHeightPx).toBeGreaterThan(0)
+    expect(maxHeightPx).toBeLessThanOrEqual(332)
   })
 
   it('renders ModelItem states for WebLLM downloads', async () => {

--- a/apps/frontend/src/components/Chat/__tests__/ModelSelect.test.tsx
+++ b/apps/frontend/src/components/Chat/__tests__/ModelSelect.test.tsx
@@ -69,12 +69,26 @@ describe('getModelDropdownMaxHeight', () => {
       }),
     ).toBe(332)
 
+    // Too cramped for a usable list: keep the readable floor and let the modal clip/scroll,
+    // rather than collapsing to a sliver (or to 0, which Mantine renders as an empty box).
     expect(
       getModelDropdownMaxHeight({
         triggerRect: { top: 150, bottom: 180 },
         containerRect: { top: 100, bottom: 220 },
       }),
-    ).toBe(42)
+    ).toBe(160)
+  })
+
+  it('never returns a height that Mantine renders as an empty dropdown', async () => {
+    const { getModelDropdownMaxHeight } = await import('../ModelSelect')
+
+    // Trigger taller than its container — both sides measure negative.
+    expect(
+      getModelDropdownMaxHeight({
+        triggerRect: { top: 100, bottom: 300 },
+        containerRect: { top: 120, bottom: 280 },
+      }),
+    ).toBe(160)
   })
 
   it('never exceeds the height cap', async () => {
@@ -86,6 +100,31 @@ describe('getModelDropdownMaxHeight', () => {
         containerRect: { top: 0, bottom: 2000 },
       }),
     ).toBe(480)
+  })
+})
+
+describe('toRemScaledDropdownHeight', () => {
+  it('passes pixel heights through unchanged at a 16px root font', async () => {
+    const { toRemScaledDropdownHeight } = await import('../ModelSelect')
+
+    expect(toRemScaledDropdownHeight(332, 16)).toBe(332)
+  })
+
+  it('shrinks the value so a larger root font still resolves to the measured pixels', async () => {
+    const { toRemScaledDropdownHeight } = await import('../ModelSelect')
+
+    // Mantine emits `value / 16` rem, so at a 20px root the prop must be pre-scaled:
+    // 265.6 / 16 = 16.6rem, and 16.6rem * 20px = 332px.
+    const scaled = toRemScaledDropdownHeight(332, 20)
+    expect(scaled).toBeCloseTo(265.6)
+    expect((scaled / 16) * 20).toBeCloseTo(332)
+  })
+
+  it('falls back to 16px for a bogus root font size', async () => {
+    const { toRemScaledDropdownHeight } = await import('../ModelSelect')
+
+    expect(toRemScaledDropdownHeight(332, 0)).toBe(332)
+    expect(toRemScaledDropdownHeight(332, Number.NaN)).toBe(332)
   })
 })
 


### PR DESCRIPTION
- Dropdown height is measured, not hardcoded
- Dropdown is no longer portalled
- Settings modal is a proper flex column

### Verifying
Open user settings at a short window height (~600px or a Nest Hub viewport) and open the model dropdown — it should stay inside the modal and scroll. Also worth checking it opening upward, where group headers should stay above their models.

e.g.
<img width="867" height="615" alt="Pasted Graphic 24" src="https://github.com/user-attachments/assets/3435e156-57e4-4556-bffb-06433e90410d" />
