### PR TITLE
Document group doc_count not updated after document delete

### DIFF
--- a/apps/backend/ai_ta_backend/rabbitmq/models.py
+++ b/apps/backend/ai_ta_backend/rabbitmq/models.py
@@ -1,347 +1,342 @@
 """
 Create models for each table in the database.
 """
+from uuid import uuid4
+
 from sqlalchemy import BigInteger
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import DateTime
+from sqlalchemy import Float
 from sqlalchemy import ForeignKey
 from sqlalchemy import Index
 from sqlalchemy import JSON
 from sqlalchemy import Text
 from sqlalchemy import VARCHAR
-from sqlalchemy import Float
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
-from uuid import uuid4
-
 try:
-    from ai_ta_backend.rabbitmq.extensions import db
+  from ai_ta_backend.rabbitmq.extensions import db
 except ModuleNotFoundError:
-    from extensions import db
+  from extensions import db
 
 
 class Base(db.Model):
-    __abstract__ = True
+  __abstract__ = True
 
 
 class Document(Base):
-    __tablename__ = 'documents'
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    created_at = Column(DateTime, default=func.now())
-    s3_path = Column(Text)
-    readable_filename = Column(Text)
-    course_name = Column(Text)
-    url = Column(Text)
-    contexts = Column(JSON, default=lambda: [{"text": "", "timestamp": "", "embedding": "", "pagenumber": ""}])
-    base_url = Column(Text)
+  __tablename__ = 'documents'
+  id = Column(BigInteger, primary_key=True, autoincrement=True)
+  created_at = Column(DateTime, default=func.now())
+  s3_path = Column(Text)
+  readable_filename = Column(Text)
+  course_name = Column(Text)
+  url = Column(Text)
+  contexts = Column(JSON, default=lambda: [{"text": "", "timestamp": "", "embedding": "", "pagenumber": ""}])
+  base_url = Column(Text)
 
-    __table_args__ = (
-        Index('documents_course_name_idx', 'course_name', postgresql_using='hash'),
-        Index('documents_created_at_idx', 'created_at', postgresql_using='btree'),
-        Index('idx_doc_s3_path', 's3_path', postgresql_using='btree'),
-    )
+  __table_args__ = (
+      Index('documents_course_name_idx', 'course_name', postgresql_using='hash'),
+      Index('documents_created_at_idx', 'created_at', postgresql_using='btree'),
+      Index('idx_doc_s3_path', 's3_path', postgresql_using='btree'),
+  )
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "created_at": self.created_at,
-            "s3_path": self.s3_path,
-            "readable_filename": self.readable_filename,
-            "course_name": self.course_name,
-            "url": self.url,
-            "contexts": self.contexts,
-            "base_url": self.base_url
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "created_at": self.created_at,
+        "s3_path": self.s3_path,
+        "readable_filename": self.readable_filename,
+        "course_name": self.course_name,
+        "url": self.url,
+        "contexts": self.contexts,
+        "base_url": self.base_url
+    }
 
 
 class DocumentDocGroup(Base):
-    __tablename__ = 'documents_doc_groups'
-    document_id = Column(BigInteger, primary_key=True)
-    doc_group_id = Column(BigInteger, ForeignKey('doc_groups.id', ondelete='CASCADE'), primary_key=True)
-    created_at = Column(DateTime, default=func.now())
+  __tablename__ = 'documents_doc_groups'
+  document_id = Column(BigInteger, ForeignKey('documents.id', ondelete='CASCADE'), primary_key=True)
+  doc_group_id = Column(BigInteger, ForeignKey('doc_groups.id', ondelete='CASCADE'), primary_key=True)
+  created_at = Column(DateTime, default=func.now())
 
-    __table_args__ = (
-        Index('documents_doc_groups_doc_group_id_idx', 'doc_group_id', postgresql_using='btree'),
-        Index('documents_doc_groups_document_id_idx', 'document_id', postgresql_using='btree'),
-    )
+  __table_args__ = (
+      Index('documents_doc_groups_doc_group_id_idx', 'doc_group_id', postgresql_using='btree'),
+      Index('documents_doc_groups_document_id_idx', 'document_id', postgresql_using='btree'),
+  )
 
-    def to_dict(self):
-        return {
-            "document_id": self.document_id,
-            "doc_group_id": self.doc_group_id,
-            "created_at": self.created_at
-        }
+  def to_dict(self):
+    return {"document_id": self.document_id, "doc_group_id": self.doc_group_id, "created_at": self.created_at}
 
 
 class DocGroup(Base):
-    __tablename__ = 'doc_groups'
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    name = Column(Text, nullable=False)
-    course_name = Column(Text, nullable=False)
-    created_at = Column(DateTime, default=func.now())
-    enabled = Column(Boolean, default=True)
-    private = Column(Boolean, default=True)
-    doc_count = Column(BigInteger)
+  __tablename__ = 'doc_groups'
+  id = Column(BigInteger, primary_key=True, autoincrement=True)
+  name = Column(Text, nullable=False)
+  course_name = Column(Text, nullable=False)
+  created_at = Column(DateTime, default=func.now())
+  enabled = Column(Boolean, default=True)
+  private = Column(Boolean, default=True)
+  doc_count = Column(BigInteger)
 
-    __table_args__ = (Index('doc_groups_enabled_course_name_idx', 'enabled', 'course_name', postgresql_using='btree'),)
+  __table_args__ = (Index('doc_groups_enabled_course_name_idx', 'enabled', 'course_name', postgresql_using='btree'),)
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "name": self.name,
-            "course_name": self.course_name,
-            "created_at": self.created_at,
-            "enabled": self.enabled,
-            "private": self.private,
-            "doc_count": self.doc_count
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "name": self.name,
+        "course_name": self.course_name,
+        "created_at": self.created_at,
+        "enabled": self.enabled,
+        "private": self.private,
+        "doc_count": self.doc_count
+    }
+
 
 def get_uuid():
-    return str(uuid4())
+  return str(uuid4())
+
 
 class DocumentsInProgress(Base):
-    __tablename__ = 'documents_in_progress'
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    created_at = Column(DateTime, default=func.now())
-    s3_path = Column(Text)
-    readable_filename = Column(Text)
-    course_name = Column(Text)
-    url = Column(Text)
-    contexts = Column(JSON, default=lambda: [{"text": "", "timestamp": "", "embedding": "", "pagenumber": ""}])
-    base_url = Column(Text)
-    doc_groups = Column(Text)
-    error = Column(Text)
-    beam_task_id = Column(Text, default=get_uuid)
+  __tablename__ = 'documents_in_progress'
+  id = Column(BigInteger, primary_key=True, autoincrement=True)
+  created_at = Column(DateTime, default=func.now())
+  s3_path = Column(Text)
+  readable_filename = Column(Text)
+  course_name = Column(Text)
+  url = Column(Text)
+  contexts = Column(JSON, default=lambda: [{"text": "", "timestamp": "", "embedding": "", "pagenumber": ""}])
+  base_url = Column(Text)
+  doc_groups = Column(Text)
+  error = Column(Text)
+  beam_task_id = Column(Text, default=get_uuid)
 
-    # __table_args__ = (Index('documents_in_progress_pkey', 'id', postgresql_using='btree'),)
+  # __table_args__ = (Index('documents_in_progress_pkey', 'id', postgresql_using='btree'),)
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "created_at": self.created_at,
-            "s3_path": self.s3_path,
-            "readable_filename": self.readable_filename,
-            "course_name": self.course_name,
-            "url": self.url,
-            "contexts": self.contexts,
-            "base_url": self.base_url,
-            "doc_groups": self.doc_groups,
-            "error": self.error,
-            "beam_task_id": self.beam_task_id
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "created_at": self.created_at,
+        "s3_path": self.s3_path,
+        "readable_filename": self.readable_filename,
+        "course_name": self.course_name,
+        "url": self.url,
+        "contexts": self.contexts,
+        "base_url": self.base_url,
+        "doc_groups": self.doc_groups,
+        "error": self.error,
+        "beam_task_id": self.beam_task_id
+    }
 
 
 class DocumentsFailed(Base):
-    __tablename__ = 'documents_failed'
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    created_at = Column(DateTime, default=func.now())
-    s3_path = Column(Text)
-    readable_filename = Column(Text)
-    course_name = Column(Text)
-    url = Column(Text)
-    contexts = Column(JSON, default=lambda: [{"text": "", "timestamp": "", "embedding": "", "pagenumber": ""}])
-    base_url = Column(Text)
-    doc_groups = Column(Text)
-    error = Column(Text)
+  __tablename__ = 'documents_failed'
+  id = Column(BigInteger, primary_key=True, autoincrement=True)
+  created_at = Column(DateTime, default=func.now())
+  s3_path = Column(Text)
+  readable_filename = Column(Text)
+  course_name = Column(Text)
+  url = Column(Text)
+  contexts = Column(JSON, default=lambda: [{"text": "", "timestamp": "", "embedding": "", "pagenumber": ""}])
+  base_url = Column(Text)
+  doc_groups = Column(Text)
+  error = Column(Text)
 
-    # __table_args__ = (Index('documents_failed_pkey', 'id', postgresql_using='btree'),)
+  # __table_args__ = (Index('documents_failed_pkey', 'id', postgresql_using='btree'),)
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "created_at": self.created_at,
-            "s3_path": self.s3_path,
-            "readable_filename": self.readable_filename,
-            "course_name": self.course_name,
-            "url": self.url,
-            "contexts": self.contexts,
-            "base_url": self.base_url,
-            "doc_groups": self.doc_groups,
-            "error": self.error,
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "created_at": self.created_at,
+        "s3_path": self.s3_path,
+        "readable_filename": self.readable_filename,
+        "course_name": self.course_name,
+        "url": self.url,
+        "contexts": self.contexts,
+        "base_url": self.base_url,
+        "doc_groups": self.doc_groups,
+        "error": self.error,
+    }
 
 
 class Project(Base):
-    __tablename__ = 'projects'
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    created_at = Column(DateTime, default=func.now())
-    course_name = Column(Text)
-    doc_map_id = Column(Text)
-    convo_map_id = Column(Text)
-    n8n_api_key = Column(Text)
-    last_uploaded_doc_id = Column(BigInteger)
-    last_uploaded_convo_id = Column(BigInteger)
-    subscribed = Column(BigInteger, ForeignKey('doc_groups.id', onupdate='CASCADE', ondelete='SET NULL'))
-    description = Column(Text)
-    metadata_schema = Column(JSON)
+  __tablename__ = 'projects'
+  id = Column(BigInteger, primary_key=True, autoincrement=True)
+  created_at = Column(DateTime, default=func.now())
+  course_name = Column(Text)
+  doc_map_id = Column(Text)
+  convo_map_id = Column(Text)
+  n8n_api_key = Column(Text)
+  last_uploaded_doc_id = Column(BigInteger)
+  last_uploaded_convo_id = Column(BigInteger)
+  subscribed = Column(BigInteger, ForeignKey('doc_groups.id', onupdate='CASCADE', ondelete='SET NULL'))
+  description = Column(Text)
+  metadata_schema = Column(JSON)
 
-    external_connection = relationship('ProjectExternalConnection', back_populates='project', uselist=False)
+  external_connection = relationship('ProjectExternalConnection', back_populates='project', uselist=False)
 
-    __table_args__ = (
-        Index('projects_course_name_key', 'course_name', postgresql_using='btree'),
-        # Index('projects_pkey', 'id', postgresql_using='btree'),
-    )
+  __table_args__ = (
+      Index('projects_course_name_key', 'course_name', postgresql_using='btree'),
+      # Index('projects_pkey', 'id', postgresql_using='btree'),
+  )
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "created_at": self.created_at,
-            "course_name": self.course_name,
-            "doc_map_id": self.doc_map_id,
-            "convo_map_id": self.convo_map_id,
-            "n8n_api_key": self.n8n_api_key,
-            "last_uploaded_doc_id": self.last_uploaded_doc_id,
-            "last_uploaded_convo_id": self.last_uploaded_convo_id,
-            "subscribed": self.subscribed,
-            "description": self.description,
-            "metadata_schema": self.metadata_schema
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "created_at": self.created_at,
+        "course_name": self.course_name,
+        "doc_map_id": self.doc_map_id,
+        "convo_map_id": self.convo_map_id,
+        "n8n_api_key": self.n8n_api_key,
+        "last_uploaded_doc_id": self.last_uploaded_doc_id,
+        "last_uploaded_convo_id": self.last_uploaded_convo_id,
+        "subscribed": self.subscribed,
+        "description": self.description,
+        "metadata_schema": self.metadata_schema
+    }
 
 
 class ProjectStats(Base):
-    __tablename__ = 'project_stats'
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    project_id = Column(BigInteger, ForeignKey('project.id')) # project_id = Column(BigInteger, ForeignKey('project.id'))
-    project_name = Column(Text)
-    total_messages= Column(BigInteger)
-    total_conversations= Column(BigInteger)
-    unique_users= Column(BigInteger)
-    created_at= Column(DateTime, default=func.now())
-    updated_at= Column(DateTime, default=func.now())
-    model_usage_counts= Column(JSON)
+  __tablename__ = 'project_stats'
+  id = Column(BigInteger, primary_key=True, autoincrement=True)
+  project_id = Column(BigInteger, ForeignKey('project.id'))  # project_id = Column(BigInteger, ForeignKey('project.id'))
+  project_name = Column(Text)
+  total_messages = Column(BigInteger)
+  total_conversations = Column(BigInteger)
+  unique_users = Column(BigInteger)
+  created_at = Column(DateTime, default=func.now())
+  updated_at = Column(DateTime, default=func.now())
+  model_usage_counts = Column(JSON)
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "project_id": self.project_id,
-            "project_name": self.project_name,
-            "total_messages": self.total_messages,
-            "total_conversations": self.total_conversations,
-            "unique_users": self.unique_users,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-            "model_usage_counts": self.model_usage_counts
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "project_id": self.project_id,
+        "project_name": self.project_name,
+        "total_messages": self.total_messages,
+        "total_conversations": self.total_conversations,
+        "unique_users": self.unique_users,
+        "created_at": self.created_at,
+        "updated_at": self.updated_at,
+        "model_usage_counts": self.model_usage_counts
+    }
+
 
 class N8nWorkflows(Base):
-    __tablename__ = 'n8n_workflows'
-    latest_workflow_id = Column(BigInteger, primary_key=True, autoincrement=True)
-    is_locked = Column(Boolean, nullable=False)
+  __tablename__ = 'n8n_workflows'
+  latest_workflow_id = Column(BigInteger, primary_key=True, autoincrement=True)
+  is_locked = Column(Boolean, nullable=False)
 
-    def __init__(self, is_locked: bool):
-        self.is_locked = is_locked
+  def __init__(self, is_locked: bool):
+    self.is_locked = is_locked
 
-    def to_dict(self):
-        return {
-            "latest_workflow_id": self.latest_workflow_id,
-            "is_locked": self.is_locked
-        }
+  def to_dict(self):
+    return {"latest_workflow_id": self.latest_workflow_id, "is_locked": self.is_locked}
 
 
 class LlmConvoMonitor(Base):
-    __tablename__ = 'llm-convo-monitor'
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    created_at = Column(DateTime, default=func.now())
-    convo = Column(JSON)
-    convo_id = Column(Text, unique=True)
-    course_name = Column(Text)
-    user_email = Column(Text)
+  __tablename__ = 'llm-convo-monitor'
+  id = Column(BigInteger, primary_key=True, autoincrement=True)
+  created_at = Column(DateTime, default=func.now())
+  convo = Column(JSON)
+  convo_id = Column(Text, unique=True)
+  course_name = Column(Text)
+  user_email = Column(Text)
 
-    __table_args__ = (
-        Index('llm_convo_monitor_course_name_idx', 'course_name', postgresql_using='hash'),
-        # Index('llm-convo-monitor_convo_id_key', 'convo_id', postgresql_using='btree'),
-        # Index('llm-convo-monitor_pkey', 'id', postgresql_using='btree'),
-    )
+  __table_args__ = (
+      Index('llm_convo_monitor_course_name_idx', 'course_name', postgresql_using='hash'),
+      # Index('llm-convo-monitor_convo_id_key', 'convo_id', postgresql_using='btree'),
+      # Index('llm-convo-monitor_pkey', 'id', postgresql_using='btree'),
+  )
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "created_at": self.created_at,
-            "convo": self.convo,
-            "convo_id": self.convo_id,
-            "course_name": self.course_name,
-            "user_email": self.user_email
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "created_at": self.created_at,
+        "convo": self.convo,
+        "convo_id": self.convo_id,
+        "course_name": self.course_name,
+        "user_email": self.user_email
+    }
 
 
 class Conversations(Base):
-    __tablename__ = 'conversations'
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    name = Column(VARCHAR)
-    model = Column(VARCHAR)
-    prompt = Column(Text)
-    temperature = Column(Float)
-    user_email = Column(VARCHAR)
-    created_at = Column(DateTime, default=func.now())
-    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
-    project_name = Column(Text)
-    folder_id = Column(UUID(as_uuid=True))
+  __tablename__ = 'conversations'
+  id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+  name = Column(VARCHAR)
+  model = Column(VARCHAR)
+  prompt = Column(Text)
+  temperature = Column(Float)
+  user_email = Column(VARCHAR)
+  created_at = Column(DateTime, default=func.now())
+  updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+  project_name = Column(Text)
+  folder_id = Column(UUID(as_uuid=True))
 
-    __table_args__ = (
-        # Index('conversations_pkey', 'id', postgresql_using='btree'),
-        Index('idx_user_email_updated_at', 'user_email', 'updated_at', postgresql_using='btree'),
-    )
+  __table_args__ = (
+      # Index('conversations_pkey', 'id', postgresql_using='btree'),
+      Index('idx_user_email_updated_at', 'user_email', 'updated_at', postgresql_using='btree'),)
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "name": self.name,
-            "model": self.model,
-            "prompt": self.prompt,
-            "temperature": self.temperature,
-            "user_email": self.user_email,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-            "project_name": self.project_name,
-            "messages": self.messages,
-            "folder_id": self.folder_id
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "name": self.name,
+        "model": self.model,
+        "prompt": self.prompt,
+        "temperature": self.temperature,
+        "user_email": self.user_email,
+        "created_at": self.created_at,
+        "updated_at": self.updated_at,
+        "project_name": self.project_name,
+        "messages": self.messages,
+        "folder_id": self.folder_id
+    }
 
 
 class Messages(Base):
-    __tablename__ = 'messages'
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    conversation_id = Column(UUID(as_uuid=True), ForeignKey('conversations.id', ondelete='CASCADE'))
-    role = Column(Text)
-    created_at = Column(DateTime, default=func.now())
-    contexts = Column(JSON)
-    tools = Column(JSON)
-    latest_system_message = Column(Text)
-    final_prompt_engineered_message = Column(Text)
-    response_time_sec = Column(BigInteger)
-    content_text = Column(Text)
-    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
-    content_image_url = Column(Text)
-    image_description = Column(Text)
+  __tablename__ = 'messages'
+  id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+  conversation_id = Column(UUID(as_uuid=True), ForeignKey('conversations.id', ondelete='CASCADE'))
+  role = Column(Text)
+  created_at = Column(DateTime, default=func.now())
+  contexts = Column(JSON)
+  tools = Column(JSON)
+  latest_system_message = Column(Text)
+  final_prompt_engineered_message = Column(Text)
+  response_time_sec = Column(BigInteger)
+  content_text = Column(Text)
+  updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+  content_image_url = Column(Text)
+  image_description = Column(Text)
 
-    # __table_args__ = (
-    #     Index('messages_pkey', 'id', postgresql_using='btree'),
-    # )
+  # __table_args__ = (
+  #     Index('messages_pkey', 'id', postgresql_using='btree'),
+  # )
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "conversation_id": self.conversation_id,
-            "role": self.role,
-            "created_at": self.created_at,
-            "contexts": self.contexts,
-            "tools": self.tools,
-            "latest_system_message": self.latest_system_message,
-            "final_prompt_engineered_message": self.final_prompt_engineered_message,
-            "response_time_sec": self.response_time_sec,
-            "content_text": self.content_text,
-            "updated_at": self.updated_at,
-            "content_image_url": self.content_image_url,
-            "image_description": self.image_description
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "conversation_id": self.conversation_id,
+        "role": self.role,
+        "created_at": self.created_at,
+        "contexts": self.contexts,
+        "tools": self.tools,
+        "latest_system_message": self.latest_system_message,
+        "final_prompt_engineered_message": self.final_prompt_engineered_message,
+        "response_time_sec": self.response_time_sec,
+        "content_text": self.content_text,
+        "updated_at": self.updated_at,
+        "content_image_url": self.content_image_url,
+        "image_description": self.image_description
+    }
 
 
 class ProjectExternalConnection(Base):
-    """Read-only mirror of the `project_external_connections` table.
+  """Read-only mirror of the `project_external_connections` table.
 
     The Next.js frontend is the sole writer (uiuc-chat-frontend
     `src/pages/api/UIUC-api/projectConnections*`). The Drizzle schema in
@@ -353,58 +348,56 @@ class ProjectExternalConnection(Base):
     as ``{"encrypted": "v1.<ct+tag>.<iv>"}``. None means "use default
     infrastructure".
     """
-    __tablename__ = 'project_external_connections'
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    project_id = Column(BigInteger, ForeignKey('projects.id', ondelete='CASCADE'), unique=True, nullable=False)
-    project_name = Column(Text, unique=True, nullable=False)
-    created_at = Column(DateTime, default=func.now())
-    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
-    s3_config = Column(JSONB, nullable=True)
-    database_config = Column(JSONB, nullable=True)
-    qdrant_config = Column(JSONB, nullable=True)
-    embedding_config = Column(JSONB, nullable=True)
-    is_active = Column(Boolean, default=True)
+  __tablename__ = 'project_external_connections'
+  id = Column(BigInteger, primary_key=True, autoincrement=True)
+  project_id = Column(BigInteger, ForeignKey('projects.id', ondelete='CASCADE'), unique=True, nullable=False)
+  project_name = Column(Text, unique=True, nullable=False)
+  created_at = Column(DateTime, default=func.now())
+  updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+  s3_config = Column(JSONB, nullable=True)
+  database_config = Column(JSONB, nullable=True)
+  qdrant_config = Column(JSONB, nullable=True)
+  embedding_config = Column(JSONB, nullable=True)
+  is_active = Column(Boolean, default=True)
 
-    project = relationship('Project', back_populates='external_connection')
+  project = relationship('Project', back_populates='external_connection')
 
-    __table_args__ = (
-        Index('pec_project_name_idx', 'project_name', postgresql_using='hash'),
-    )
+  __table_args__ = (Index('pec_project_name_idx', 'project_name', postgresql_using='hash'),)
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "project_id": self.project_id,
-            "project_name": self.project_name,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-            "s3_config": self.s3_config,
-            "database_config": self.database_config,
-            "qdrant_config": self.qdrant_config,
-            "embedding_config": self.embedding_config,
-            "is_active": self.is_active,
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "project_id": self.project_id,
+        "project_name": self.project_name,
+        "created_at": self.created_at,
+        "updated_at": self.updated_at,
+        "s3_config": self.s3_config,
+        "database_config": self.database_config,
+        "qdrant_config": self.qdrant_config,
+        "embedding_config": self.embedding_config,
+        "is_active": self.is_active,
+    }
 
 
 class PreAuthAPIKeys(Base):
-    __tablename__ = 'pre_authorized_api_keys'
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    created_at = Column(DateTime, default=func.now())
-    emails = Column(JSONB)
-    providerBodyNoModels = Column(JSON)
-    providerName = Column(Text)
-    notes = Column(Text)
+  __tablename__ = 'pre_authorized_api_keys'
+  id = Column(BigInteger, primary_key=True, autoincrement=True)
+  created_at = Column(DateTime, default=func.now())
+  emails = Column(JSONB)
+  providerBodyNoModels = Column(JSON)
+  providerName = Column(Text)
+  notes = Column(Text)
 
-    # __table_args__ = (
-    #     Index('pre-authorized-api-keys_pkey', 'id', postgresql_using='btree'),
-    # )
+  # __table_args__ = (
+  #     Index('pre-authorized-api-keys_pkey', 'id', postgresql_using='btree'),
+  # )
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "created_at": self.created_at,
-            "emails": self.emails,
-            "providerBodyNoModels": self.providerBodyNoModels,
-            "providerName": self.providerName,
-            "notes": self.notes
-        }
+  def to_dict(self):
+    return {
+        "id": self.id,
+        "created_at": self.created_at,
+        "emails": self.emails,
+        "providerBodyNoModels": self.providerBodyNoModels,
+        "providerName": self.providerName,
+        "notes": self.notes
+    }

--- a/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
+++ b/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
@@ -371,7 +371,7 @@ export function ProjectFilesTable({
             if (decrement === 0) return doc_group
             return {
               ...doc_group,
-              doc_count: (doc_group.doc_count || 0) - decrement,
+              doc_count: Math.max(0, (doc_group.doc_count || 0) - decrement),
             }
           })
         },

--- a/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
+++ b/apps/frontend/src/components/UIUC-Components/ProjectFilesTable.tsx
@@ -362,12 +362,17 @@ export function ProjectFilesTable({
         ['documentGroups', course_name],
         (old = []) => {
           return old.map((doc_group) => {
-            recordsToDelete.forEach((record) => {
-              if (doc_group.name in record.doc_groups) {
-                doc_group.doc_count -= 1
+            const decrement = recordsToDelete.reduce((count, record) => {
+              if (record.doc_groups?.includes(doc_group.name)) {
+                return count + 1
               }
-            })
-            return doc_group
+              return count
+            }, 0)
+            if (decrement === 0) return doc_group
+            return {
+              ...doc_group,
+              doc_count: (doc_group.doc_count || 0) - decrement,
+            }
           })
         },
       )

--- a/apps/frontend/src/db/migrations/0013_documents_doc_groups_cascade.sql
+++ b/apps/frontend/src/db/migrations/0013_documents_doc_groups_cascade.sql
@@ -1,0 +1,79 @@
+-- Match Original DB Schema: cascade junction deletes when a document (or group) is
+-- removed so trg_update_doc_count_after_insert keeps doc_groups.doc_count in sync.
+--
+-- Existing self-hosted DBs may have orphaned junction rows and drifted
+-- doc_count. Order matters:
+--   1. Disable the count trigger (orphan DELETEs would otherwise push already-
+--      wrong counts further negative)
+--   2. Delete orphaned junction rows
+--   3. Recompute doc_count from the junction table
+--   4. Re-enable the trigger
+--   5. Add the FK constraints
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_update_doc_count_after_insert'
+      AND tgrelid = 'public.documents_doc_groups'::regclass
+  ) THEN
+    ALTER TABLE "documents_doc_groups" DISABLE TRIGGER trg_update_doc_count_after_insert;
+  END IF;
+END $$;
+--> statement-breakpoint
+
+DELETE FROM "documents_doc_groups" ddg
+WHERE NOT EXISTS (
+  SELECT 1 FROM "documents" d WHERE d.id = ddg.document_id
+);
+--> statement-breakpoint
+DELETE FROM "documents_doc_groups" ddg
+WHERE NOT EXISTS (
+  SELECT 1 FROM "doc_groups" dg WHERE dg.id = ddg.doc_group_id
+);
+--> statement-breakpoint
+
+UPDATE "doc_groups" dg
+SET doc_count = (
+  SELECT COUNT(*) FROM "documents_doc_groups" ddg WHERE ddg.doc_group_id = dg.id
+);
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_update_doc_count_after_insert'
+      AND tgrelid = 'public.documents_doc_groups'::regclass
+  ) THEN
+    ALTER TABLE "documents_doc_groups" ENABLE TRIGGER trg_update_doc_count_after_insert;
+  END IF;
+END $$;
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'documents_doc_groups_document_id_documents_id_fk'
+  ) THEN
+    ALTER TABLE "documents_doc_groups"
+      ADD CONSTRAINT "documents_doc_groups_document_id_documents_id_fk"
+      FOREIGN KEY ("document_id") REFERENCES "public"."documents"("id")
+      ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'documents_doc_groups_doc_group_id_doc_groups_id_fk'
+  ) THEN
+    ALTER TABLE "documents_doc_groups"
+      ADD CONSTRAINT "documents_doc_groups_doc_group_id_doc_groups_id_fk"
+      FOREIGN KEY ("doc_group_id") REFERENCES "public"."doc_groups"("id")
+      ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;

--- a/apps/frontend/src/db/migrations/0014_add_document_to_group_fk_noop.sql
+++ b/apps/frontend/src/db/migrations/0014_add_document_to_group_fk_noop.sql
@@ -1,0 +1,116 @@
+-- Swallow foreign_key_violation in add_document_to_group{,_url} when a document
+-- (or group) is deleted between resolve and junction insert. With
+-- ON DELETE CASCADE FKs that race used to leave an orphan; re-raising now
+-- fails ingest. Treat it as a no-op instead.
+
+CREATE OR REPLACE FUNCTION public.add_document_to_group(p_course_name text, p_s3_path text, p_url text, p_readable_filename text, p_doc_groups text[]) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$DECLARE
+    v_document_id bigint;
+    v_doc_group_id bigint;
+    v_success boolean := true;
+    p_doc_group text;
+BEGIN
+    -- Ensure the document exists
+    SELECT id INTO v_document_id FROM public.documents WHERE course_name = p_course_name AND (
+    (s3_path <> '' AND s3_path IS NOT NULL AND s3_path = p_s3_path)
+);
+
+    raise log 'id of document: %', v_document_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Document does not exist';
+    END IF;
+
+    -- Loop through document groups
+    FOREACH p_doc_group IN ARRAY p_doc_groups
+    LOOP
+        -- Upsert document group, assuming 'name' and 'course_name' can uniquely identify a row
+        INSERT INTO public.doc_groups(name, course_name)
+        VALUES (p_doc_group, p_course_name)
+        ON CONFLICT (name, course_name) DO UPDATE
+        SET name = EXCLUDED.name
+        RETURNING id INTO v_doc_group_id;
+
+        raise log 'id of document group: %', v_doc_group_id;
+
+        -- Upsert the association in documents_doc_groups.
+        -- Concurrent delete between SELECT and INSERT: no-op (do not fail ingest).
+        BEGIN
+            INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
+            VALUES (v_document_id, v_doc_group_id)
+            ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        EXCEPTION
+            WHEN foreign_key_violation THEN
+                RAISE LOG 'add_document_to_group: skipping FK violation for document_id=% doc_group_id=%',
+                    v_document_id, v_doc_group_id;
+        END;
+
+        raise log 'completed for %',v_doc_group_id;
+    END LOOP;
+
+    raise log 'completed for %',v_document_id;
+    RETURN v_success;
+EXCEPTION
+    WHEN OTHERS THEN
+        v_success := false;
+        RAISE;
+        RETURN v_success;
+END;$$;
+--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION public.add_document_to_group_url(p_course_name text, p_s3_path text, p_url text, p_readable_filename text, p_doc_groups text[]) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$DECLARE
+    v_document_id bigint;
+    v_doc_group_id bigint;
+    v_success boolean := true;
+    p_doc_group text;
+BEGIN
+    -- Ensure the document exists
+    SELECT id INTO v_document_id FROM public.documents WHERE course_name = p_course_name AND (
+    (s3_path <> '' AND s3_path IS NOT NULL AND s3_path = p_s3_path) OR
+    (url = p_url)
+);
+
+    raise log 'id of document: %', v_document_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Document does not exist';
+    END IF;
+
+    -- Loop through document groups
+    FOREACH p_doc_group IN ARRAY p_doc_groups
+    LOOP
+        -- Upsert document group, assuming 'name' and 'course_name' can uniquely identify a row
+        INSERT INTO public.doc_groups(name, course_name)
+        VALUES (p_doc_group, p_course_name)
+        ON CONFLICT (name, course_name) DO UPDATE
+        SET name = EXCLUDED.name
+        RETURNING id INTO v_doc_group_id;
+
+        raise log 'id of document group: %', v_doc_group_id;
+
+        -- Upsert the association in documents_doc_groups.
+        -- Concurrent delete between SELECT and INSERT: no-op (do not fail ingest).
+        BEGIN
+            INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
+            VALUES (v_document_id, v_doc_group_id)
+            ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        EXCEPTION
+            WHEN foreign_key_violation THEN
+                RAISE LOG 'add_document_to_group_url: skipping FK violation for document_id=% doc_group_id=%',
+                    v_document_id, v_doc_group_id;
+        END;
+
+        raise log 'completed for %',v_doc_group_id;
+    END LOOP;
+
+    raise log 'completed for %',v_document_id;
+    RETURN v_success;
+EXCEPTION
+    WHEN OTHERS THEN
+        v_success := false;
+        RAISE;
+        RETURN v_success;
+END;$$;

--- a/apps/frontend/src/db/migrations/meta/_journal.json
+++ b/apps/frontend/src/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1779081700000,
       "tag": "0013_documents_doc_groups_cascade",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1779081800000,
+      "tag": "0014_add_document_to_group_fk_noop",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/frontend/src/db/migrations/meta/_journal.json
+++ b/apps/frontend/src/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1779081600000,
       "tag": "0012_chatbot_tags",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1779081700000,
+      "tag": "0013_documents_doc_groups_cascade",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/frontend/src/db/schema.ts
+++ b/apps/frontend/src/db/schema.ts
@@ -337,8 +337,12 @@ export const docGroups = pgTable(
 export const documentsDocGroups = pgTable(
   'documents_doc_groups',
   {
-    document_id: bigint('document_id', { mode: 'number' }).notNull(),
-    doc_group_id: bigint('doc_group_id', { mode: 'number' }).notNull(),
+    document_id: bigint('document_id', { mode: 'number' })
+      .notNull()
+      .references(() => documents.id, { onDelete: 'cascade' }),
+    doc_group_id: bigint('doc_group_id', { mode: 'number' })
+      .notNull()
+      .references(() => docGroups.id, { onDelete: 'cascade' }),
     created_at: timestamp('created_at').defaultNow(),
   },
   (table) => {

--- a/docs/external-connections-setup.md
+++ b/docs/external-connections-setup.md
@@ -12,7 +12,8 @@ This guide covers operator setup:
 1. [Prerequisites](#prerequisites)
 2. [Provisioning an external Postgres (documents + pgvector)](#provisioning-an-external-postgres)
 3. [Registering a project's connections with the CLI](#registering-connections-with-the-cli)
-4. [Verifying and troubleshooting](#verifying-and-troubleshooting)
+4. [Keeping existing external stores up to date](#keeping-existing-external-stores-up-to-date)
+5. [Verifying and troubleshooting](#verifying-and-troubleshooting)
 
 Deeper reference material lives with the apps:
 
@@ -24,7 +25,7 @@ Deeper reference material lives with the apps:
 
 ## Prerequisites
 
-- **`ENCRYPTION_MASTER_KEY`** must be set to the *same value* for the
+- **`ENCRYPTION_MASTER_KEY`** must be set to the _same value_ for the
   frontend, backend, and ingest worker — configs are stored AES-256-GCM
   encrypted, written by the frontend and decrypted by all three. The dev
   bootstrap (`infra/scripts/start-dev.sh`) generates one and syncs it into
@@ -78,7 +79,7 @@ it; the script runs `CREATE EXTENSION IF NOT EXISTS vector` itself.
 > already holds millions of embeddings, read the notes inside
 > `infra/db/provision_external_pgvector_store.sql` about
 > `maintenance_work_mem` and serial (non-parallel) `CREATE INDEX
-> CONCURRENTLY` builds first — getting this wrong turns a ~1 hour build into
+CONCURRENTLY` builds first — getting this wrong turns a ~1 hour build into
 > days.
 
 ## Registering connections with the CLI
@@ -179,6 +180,33 @@ is stored verbatim; no automatic port rewriting is done.
 - Config changes take effect immediately for new requests (the API
   invalidates the per-project cache on every successful write).
 
+## Keeping existing external stores up to date
+
+`npm run db:migrate` only touches the **host** database, and
+`provision_external_pgvector_store.sql` only runs when a store is first
+provisioned. Schema changes to the document/ingest tables therefore never reach
+an already-provisioned external Postgres on their own.
+
+`infra/db/external-migrations/` holds an ordered set of idempotent SQL scripts
+for exactly that. Replay the whole set against each external store after
+pulling a release that changed document schema:
+
+```bash
+infra/db/external-migrations/apply.sh "postgresql://user:password@db-host:5432/dbname"
+```
+
+Every script is safe to re-run, so there is nothing to track per store — a store
+that is already current is left unchanged. As with provisioning, use a direct or
+session-mode connection (not the transaction pooler), with a role that owns the
+document tables.
+
+Freshly provisioned stores do **not** need this: the provisioning script is kept
+in sync and already includes every change.
+
+Contributors: the convention for adding to that directory — and the rule that
+`provision_external_pgvector_store.sql` moves with it — is documented in
+[`infra/db/external-migrations/README.md`](../infra/db/external-migrations/README.md).
+
 ## Verifying and troubleshooting
 
 - `test` probes run server-side with SSRF protections — private/loopback
@@ -193,5 +221,9 @@ is stored verbatim; no automatic port rewriting is done.
 - Ingest writes fail against an external Postgres if it was not provisioned —
   the worker expects the RPCs and tables from
   `provision_external_pgvector_store.sql` to exist.
+- Document-group counts that look wrong only for projects on an external
+  Postgres usually mean the store is behind on
+  [external migrations](#keeping-existing-external-stores-up-to-date); replaying
+  them repairs the drift as well as preventing it.
 - Every write is recorded in `project_connection_audit_log` (actor, action,
   changed field names — never values) on the host database.

--- a/infra/db/external-migrations/0001_documents_doc_groups_cascade.sql
+++ b/infra/db/external-migrations/0001_documents_doc_groups_cascade.sql
@@ -1,0 +1,88 @@
+-- 0001_documents_doc_groups_cascade.sql
+--
+-- External-store port of apps/frontend/src/db/migrations/
+-- 0013_documents_doc_groups_cascade.sql.
+--
+-- Cascade junction deletes when a document (or group) is removed, so
+-- trg_update_doc_count_after_insert keeps doc_groups.doc_count in sync, and
+-- repair the drift left behind by deletes that happened before the FKs existed.
+--
+-- Order matters:
+--   1. Disable the count trigger (orphan DELETEs would otherwise push
+--      already-wrong counts further negative)
+--   2. Delete orphaned junction rows
+--   3. Recompute doc_count from the junction table
+--   4. Re-enable the trigger
+--   5. Add the FK constraints
+--
+-- Unlike the equivalent block in provision_external_pgvector_store.sql — which
+-- skips the repair once the FKs exist, because a freshly provisioned store has
+-- nothing to repair — steps 1-4 run unconditionally here. Counts on a live
+-- store can drift for reasons unrelated to the FKs, and re-running the repair
+-- is the point of replaying this file.
+--
+-- Requires ownership of public.documents_doc_groups (ALTER TABLE ... DISABLE
+-- TRIGGER). Safe to re-run.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.documents_doc_groups') IS NULL THEN
+    RAISE EXCEPTION 'public.documents_doc_groups is missing — provision this store with infra/db/provision_external_pgvector_store.sql first';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_update_doc_count_after_insert'
+      AND tgrelid = 'public.documents_doc_groups'::regclass
+  ) THEN
+    ALTER TABLE public.documents_doc_groups
+      DISABLE TRIGGER trg_update_doc_count_after_insert;
+  END IF;
+
+  DELETE FROM public.documents_doc_groups ddg
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.documents d WHERE d.id = ddg.document_id
+  );
+
+  DELETE FROM public.documents_doc_groups ddg
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.doc_groups dg WHERE dg.id = ddg.doc_group_id
+  );
+
+  UPDATE public.doc_groups dg
+  SET doc_count = (
+    SELECT COUNT(*) FROM public.documents_doc_groups ddg
+    WHERE ddg.doc_group_id = dg.id
+  );
+
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_update_doc_count_after_insert'
+      AND tgrelid = 'public.documents_doc_groups'::regclass
+  ) THEN
+    ALTER TABLE public.documents_doc_groups
+      ENABLE TRIGGER trg_update_doc_count_after_insert;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'documents_doc_groups_document_id_documents_id_fk'
+  ) THEN
+    ALTER TABLE public.documents_doc_groups
+      ADD CONSTRAINT documents_doc_groups_document_id_documents_id_fk
+      FOREIGN KEY (document_id) REFERENCES public.documents(id) ON DELETE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'documents_doc_groups_doc_group_id_doc_groups_id_fk'
+  ) THEN
+    ALTER TABLE public.documents_doc_groups
+      ADD CONSTRAINT documents_doc_groups_doc_group_id_doc_groups_id_fk
+      FOREIGN KEY (doc_group_id) REFERENCES public.doc_groups(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+COMMIT;

--- a/infra/db/external-migrations/0002_add_document_to_group_fk_noop.sql
+++ b/infra/db/external-migrations/0002_add_document_to_group_fk_noop.sql
@@ -1,0 +1,127 @@
+-- 0002_add_document_to_group_fk_noop.sql
+--
+-- External-store port of apps/frontend/src/db/migrations/
+-- 0014_add_document_to_group_fk_noop.sql.
+--
+-- Swallow foreign_key_violation in add_document_to_group{,_url} when a document
+-- (or group) is deleted between resolve and junction insert. Before 0001 that
+-- race left an orphan; with ON DELETE CASCADE FKs in place it fails ingest
+-- instead. Treat it as a logged no-op.
+--
+-- Bodies must stay identical to the ones in
+-- infra/db/provision_external_pgvector_store.sql. Safe to re-run.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.add_document_to_group(p_course_name text, p_s3_path text, p_url text, p_readable_filename text, p_doc_groups text[]) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$DECLARE
+    v_document_id bigint;
+    v_doc_group_id bigint;
+    v_success boolean := true;
+    p_doc_group text;
+BEGIN
+    -- Ensure the document exists
+    SELECT id INTO v_document_id FROM public.documents WHERE course_name = p_course_name AND (
+    (s3_path <> '' AND s3_path IS NOT NULL AND s3_path = p_s3_path)
+);
+
+    raise log 'id of document: %', v_document_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Document does not exist';
+    END IF;
+
+    -- Loop through document groups
+    FOREACH p_doc_group IN ARRAY p_doc_groups
+    LOOP
+        -- Upsert document group, assuming 'name' and 'course_name' can uniquely identify a row
+        INSERT INTO public.doc_groups(name, course_name)
+        VALUES (p_doc_group, p_course_name)
+        ON CONFLICT (name, course_name) DO UPDATE
+        SET name = EXCLUDED.name
+        RETURNING id INTO v_doc_group_id;
+
+        raise log 'id of document group: %', v_doc_group_id;
+
+        -- Upsert the association in documents_doc_groups.
+        -- Concurrent delete between SELECT and INSERT: no-op (do not fail ingest).
+        BEGIN
+            INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
+            VALUES (v_document_id, v_doc_group_id)
+            ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        EXCEPTION
+            WHEN foreign_key_violation THEN
+                RAISE LOG 'add_document_to_group: skipping FK violation for document_id=% doc_group_id=%',
+                    v_document_id, v_doc_group_id;
+        END;
+
+        raise log 'completed for %',v_doc_group_id;
+    END LOOP;
+
+    raise log 'completed for %',v_document_id;
+    RETURN v_success;
+EXCEPTION
+    WHEN OTHERS THEN
+        v_success := false;
+        RAISE;
+        RETURN v_success;
+END;$$;
+
+CREATE OR REPLACE FUNCTION public.add_document_to_group_url(p_course_name text, p_s3_path text, p_url text, p_readable_filename text, p_doc_groups text[]) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$DECLARE
+    v_document_id bigint;
+    v_doc_group_id bigint;
+    v_success boolean := true;
+    p_doc_group text;
+BEGIN
+    -- Ensure the document exists
+    SELECT id INTO v_document_id FROM public.documents WHERE course_name = p_course_name AND (
+    (s3_path <> '' AND s3_path IS NOT NULL AND s3_path = p_s3_path) OR
+    (url = p_url)
+);
+
+    raise log 'id of document: %', v_document_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Document does not exist';
+    END IF;
+
+    -- Loop through document groups
+    FOREACH p_doc_group IN ARRAY p_doc_groups
+    LOOP
+        -- Upsert document group, assuming 'name' and 'course_name' can uniquely identify a row
+        INSERT INTO public.doc_groups(name, course_name)
+        VALUES (p_doc_group, p_course_name)
+        ON CONFLICT (name, course_name) DO UPDATE
+        SET name = EXCLUDED.name
+        RETURNING id INTO v_doc_group_id;
+
+        raise log 'id of document group: %', v_doc_group_id;
+
+        -- Upsert the association in documents_doc_groups.
+        -- Concurrent delete between SELECT and INSERT: no-op (do not fail ingest).
+        BEGIN
+            INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
+            VALUES (v_document_id, v_doc_group_id)
+            ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        EXCEPTION
+            WHEN foreign_key_violation THEN
+                RAISE LOG 'add_document_to_group_url: skipping FK violation for document_id=% doc_group_id=%',
+                    v_document_id, v_doc_group_id;
+        END;
+
+        raise log 'completed for %',v_doc_group_id;
+    END LOOP;
+
+    raise log 'completed for %',v_document_id;
+    RETURN v_success;
+EXCEPTION
+    WHEN OTHERS THEN
+        v_success := false;
+        RAISE;
+        RETURN v_success;
+END;$$;
+
+COMMIT;

--- a/infra/db/external-migrations/README.md
+++ b/infra/db/external-migrations/README.md
@@ -1,0 +1,99 @@
+# External store migrations
+
+Ordered, idempotent SQL scripts that bring an **external per-project Postgres**
+(a project's `database` connection) up to date with document-related schema
+changes made in the host database.
+
+## Why this exists
+
+Document schema changes reach three places, and only two of them are automatic:
+
+| Target                                    | How it gets the change                                                     |
+| ----------------------------------------- | -------------------------------------------------------------------------- |
+| Host Postgres                             | `npm run db:migrate` (Drizzle, `apps/frontend/src/db/migrations/`)         |
+| **Newly provisioned** external Postgres   | `infra/db/provision_external_pgvector_store.sql`, run once by the operator |
+| **Already provisioned** external Postgres | Nothing — that is the gap this directory fills                             |
+
+Drizzle migrations never run against external stores, and the provisioning
+script only runs at provision time. Without an ordered set of scripts here,
+every schema change has to be hand-ported to each existing external store from
+memory.
+
+## The convention
+
+When a PR changes document-related schema — the `documents`, `doc_groups`,
+`documents_doc_groups`, `documents_in_progress`, `documents_failed`, or
+`embeddings` tables, or any trigger or function on the ingest/delete paths —
+ship the change in **three** places:
+
+1. A Drizzle migration under `apps/frontend/src/db/migrations/` (host).
+2. A numbered file here, `NNNN_short_description.sql`, as a standalone SQL
+   diff for external stores.
+3. The corresponding edit to `infra/db/provision_external_pgvector_store.sql`,
+   so freshly provisioned stores match without needing to replay anything.
+
+Host-only concerns (`projects`, `project_external_connections`, the audit log,
+chat and analytics tables) do **not** belong here — external stores never have
+those tables.
+
+### Rules for files in this directory
+
+- **Idempotent.** Every file must be safe to run any number of times, against a
+  store that is fully current and against one many migrations behind. Guard DDL
+  with `IF NOT EXISTS` / `pg_constraint` / `pg_trigger` lookups, and prefer
+  `CREATE OR REPLACE` for functions. There is deliberately no bookkeeping table:
+  idempotency is what makes replay safe, so nothing needs to track which files
+  already ran.
+- **Plain psql.** No Drizzle `--> statement-breakpoint` markers, no
+  `\` meta-commands, no provider-specific syntax — these get run through `psql`
+  or a provider SQL runner (e.g. Supabase's `apply_migration`).
+- **Self-contained and transactional.** Wrap the file in `BEGIN` / `COMMIT` so a
+  partial application cannot leave a store half-migrated. If a change cannot run
+  inside a transaction (`CREATE INDEX CONCURRENTLY`, for instance), say so in the
+  file header and leave the transaction out.
+- **Numbered sequentially**, zero-padded to four digits, never renumbered or
+  edited after merge. Fix a bad migration with a new one.
+- **Cross-referenced.** The header should name the host migration it ports, so
+  the pairing stays obvious.
+
+Numbering here is independent of the Drizzle sequence — most host migrations
+have no external counterpart, so the two will drift apart. `0001`/`0002` port
+host `0013`/`0014`.
+
+## Applying them
+
+Replay the full set against each external store; idempotency makes this safe
+regardless of how far behind the store is.
+
+```bash
+infra/db/external-migrations/apply.sh "postgresql://user:pass@host:5432/dbname"
+```
+
+Or by hand, in numeric order:
+
+```bash
+psql "postgresql://user:pass@host:5432/dbname" -v ON_ERROR_STOP=1 \
+  -f infra/db/external-migrations/0001_documents_doc_groups_cascade.sql
+```
+
+`apply.sh --dry-run` lists what would run; `apply.sh --only 0001` applies a
+single file. The connection URI can also come from `EXTERNAL_DATABASE_URI`.
+
+Notes:
+
+- Use a **direct or session-mode** connection (Supabase port 5432), not the
+  transaction pooler — these scripts execute DDL. The pooler URI is for the
+  registered runtime `connection_uri` only.
+- The connecting role must **own** the affected tables. `0001` toggles a trigger
+  with `ALTER TABLE ... DISABLE TRIGGER`, which requires ownership.
+- Run against a store that has already been provisioned. `0001` raises a clear
+  error if `documents_doc_groups` is missing, which means the store needs
+  `provision_external_pgvector_store.sql` first — that script is current, so no
+  replay is needed afterwards.
+
+## Index
+
+| File                                     | Ports host migration | Change                                                                                 |
+| ---------------------------------------- | -------------------- | -------------------------------------------------------------------------------------- |
+| `0001_documents_doc_groups_cascade.sql`  | `0013`               | `ON DELETE CASCADE` FKs on the junction table; clean orphans and recompute `doc_count` |
+| `0002_add_document_to_group_fk_noop.sql` | `0014`               | `add_document_to_group{,_url}` treat a mid-ingest FK violation as a logged no-op       |

--- a/infra/db/external-migrations/apply.sh
+++ b/infra/db/external-migrations/apply.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# apply.sh — replay the external-store migrations, in order, against one
+# external per-project Postgres.
+#
+# Every file in this directory is idempotent, so there is no bookkeeping table
+# and no "current version" to track: applying the whole set brings a store up
+# to date whether it is one migration behind or ten.
+#
+#   ./apply.sh "postgresql://user:pass@host:5432/dbname"
+#   EXTERNAL_DATABASE_URI="postgresql://..." ./apply.sh
+#   ./apply.sh --dry-run "postgresql://..."
+#   ./apply.sh --only 0001 "postgresql://..."
+#
+# Use a direct or session-mode connection (e.g. Supabase port 5432), not the
+# transaction pooler — these run DDL. See docs/external-connections-setup.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+	cat <<'EOF'
+apply.sh — replay the external-store migrations, in order, against one
+external per-project Postgres. Every file is idempotent, so applying the whole
+set brings a store up to date however far behind it is.
+
+Usage:
+  ./apply.sh "postgresql://user:pass@host:5432/dbname"
+  EXTERNAL_DATABASE_URI="postgresql://..." ./apply.sh
+
+Options:
+  --dry-run       List the files that would be applied, without running them.
+  --only <NNNN>   Apply only the migration with that number prefix.
+  -h, --help      Show this help.
+
+Use a direct or session-mode connection (e.g. Supabase port 5432), not the
+transaction pooler — these run DDL. See docs/external-connections-setup.md.
+EOF
+}
+
+dry_run=false
+only=""
+uri="${EXTERNAL_DATABASE_URI-}"
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--dry-run)
+		dry_run=true
+		shift
+		;;
+	--only)
+		only="${2-}"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	-*)
+		echo "unknown option: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	*)
+		uri="$1"
+		shift
+		;;
+	esac
+done
+
+if [[ -z ${uri} ]]; then
+	echo "error: no connection URI (pass one as an argument or set EXTERNAL_DATABASE_URI)" >&2
+	usage >&2
+	exit 2
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+	echo "error: psql not found on PATH" >&2
+	exit 1
+fi
+
+shopt -s nullglob
+files=()
+for candidate in "${SCRIPT_DIR}"/[0-9][0-9][0-9][0-9]_*.sql; do
+	files+=("${candidate}")
+done
+shopt -u nullglob
+
+if [[ ${#files[@]} -eq 0 ]]; then
+	echo "error: no migration files found in ${SCRIPT_DIR}" >&2
+	exit 1
+fi
+
+for file in "${files[@]}"; do
+	name="$(basename "${file}")"
+
+	if [[ -n ${only} && ${name} != "${only}"* ]]; then
+		continue
+	fi
+
+	if [[ ${dry_run} == true ]]; then
+		echo "would apply: ${name}"
+		continue
+	fi
+
+	echo "==> applying ${name}"
+	psql "${uri}" -v ON_ERROR_STOP=1 --quiet -f "${file}"
+done
+
+if [[ ${dry_run} != true ]]; then
+	echo "==> done"
+fi

--- a/infra/db/init-schema.sql
+++ b/infra/db/init-schema.sql
@@ -438,6 +438,8 @@ CREATE TABLE "usage_metrics" (
 );
 --> statement-breakpoint
 ALTER TABLE "project_external_connections" ADD CONSTRAINT "project_external_connections_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "documents_doc_groups" ADD CONSTRAINT "documents_doc_groups_document_id_documents_id_fk" FOREIGN KEY ("document_id") REFERENCES "public"."documents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "documents_doc_groups" ADD CONSTRAINT "documents_doc_groups_doc_group_id_doc_groups_id_fk" FOREIGN KEY ("doc_group_id") REFERENCES "public"."doc_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "doc_groups_name_course_unique" ON "doc_groups" USING btree ("name","course_name");--> statement-breakpoint
 CREATE UNIQUE INDEX "documents_doc_groups_pkey" ON "documents_doc_groups" USING btree ("document_id","doc_group_id");--> statement-breakpoint
 CREATE INDEX "embeddings_embedding_1536_hnsw_idx" ON "embeddings" USING hnsw ((subvector("embedding", 1, 1536)::vector(1536)) vector_cosine_ops) WITH (m=16,ef_construction=64);--> statement-breakpoint

--- a/infra/db/init-schema.sql
+++ b/infra/db/init-schema.sql
@@ -488,10 +488,17 @@ BEGIN
 
         raise log 'id of document group: %', v_doc_group_id;
 
-        -- Upsert the association in documents_doc_groups
-        INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
-        VALUES (v_document_id, v_doc_group_id)
-        ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        -- Upsert the association in documents_doc_groups.
+        -- Concurrent delete between SELECT and INSERT: no-op (do not fail ingest).
+        BEGIN
+            INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
+            VALUES (v_document_id, v_doc_group_id)
+            ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        EXCEPTION
+            WHEN foreign_key_violation THEN
+                RAISE LOG 'add_document_to_group: skipping FK violation for document_id=% doc_group_id=%',
+                    v_document_id, v_doc_group_id;
+        END;
 
         raise log 'completed for %',v_doc_group_id;
     END LOOP;
@@ -540,10 +547,17 @@ BEGIN
 
         raise log 'id of document group: %', v_doc_group_id;
 
-        -- Upsert the association in documents_doc_groups
-        INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
-        VALUES (v_document_id, v_doc_group_id)
-        ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        -- Upsert the association in documents_doc_groups.
+        -- Concurrent delete between SELECT and INSERT: no-op (do not fail ingest).
+        BEGIN
+            INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
+            VALUES (v_document_id, v_doc_group_id)
+            ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        EXCEPTION
+            WHEN foreign_key_violation THEN
+                RAISE LOG 'add_document_to_group_url: skipping FK violation for document_id=% doc_group_id=%',
+                    v_document_id, v_doc_group_id;
+        END;
 
         raise log 'completed for %',v_doc_group_id;
     END LOOP;

--- a/infra/db/provision_external_pgvector_store.sql
+++ b/infra/db/provision_external_pgvector_store.sql
@@ -55,12 +55,69 @@ CREATE TABLE IF NOT EXISTS public.doc_groups (
 );
 
 -- documents_doc_groups: many-to-many junction (composite PK)
+-- ON DELETE CASCADE on document_id keeps doc_groups.doc_count in sync via
+-- trg_update_doc_count_after_insert when documents are deleted.
 CREATE TABLE IF NOT EXISTS public.documents_doc_groups (
   document_id  bigint NOT NULL,
   doc_group_id bigint NOT NULL,
   created_at   timestamp with time zone NOT NULL DEFAULT now(),
   CONSTRAINT documents_doc_groups_pkey PRIMARY KEY (document_id, doc_group_id)
 );
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'documents_doc_groups_document_id_documents_id_fk'
+  ) THEN
+    -- Disable count trigger while cleaning orphans so already-drifted
+    -- doc_count values are not driven further negative, then recompute.
+    IF EXISTS (
+      SELECT 1 FROM pg_trigger
+      WHERE tgname = 'trg_update_doc_count_after_insert'
+        AND tgrelid = 'public.documents_doc_groups'::regclass
+    ) THEN
+      ALTER TABLE public.documents_doc_groups
+        DISABLE TRIGGER trg_update_doc_count_after_insert;
+    END IF;
+
+    DELETE FROM public.documents_doc_groups ddg
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.documents d WHERE d.id = ddg.document_id
+    );
+    DELETE FROM public.documents_doc_groups ddg
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.doc_groups dg WHERE dg.id = ddg.doc_group_id
+    );
+    UPDATE public.doc_groups dg
+    SET doc_count = (
+      SELECT COUNT(*) FROM public.documents_doc_groups ddg
+      WHERE ddg.doc_group_id = dg.id
+    );
+
+    IF EXISTS (
+      SELECT 1 FROM pg_trigger
+      WHERE tgname = 'trg_update_doc_count_after_insert'
+        AND tgrelid = 'public.documents_doc_groups'::regclass
+    ) THEN
+      ALTER TABLE public.documents_doc_groups
+        ENABLE TRIGGER trg_update_doc_count_after_insert;
+    END IF;
+
+    ALTER TABLE public.documents_doc_groups
+      ADD CONSTRAINT documents_doc_groups_document_id_documents_id_fk
+      FOREIGN KEY (document_id) REFERENCES public.documents(id) ON DELETE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'documents_doc_groups_doc_group_id_doc_groups_id_fk'
+  ) THEN
+    ALTER TABLE public.documents_doc_groups
+      ADD CONSTRAINT documents_doc_groups_doc_group_id_doc_groups_id_fk
+      FOREIGN KEY (doc_group_id) REFERENCES public.doc_groups(id) ON DELETE CASCADE;
+  END IF;
+END $$;
 
 -- documents_in_progress: ingest job tracking (beam_task_id == queue job_id)
 CREATE TABLE IF NOT EXISTS public.documents_in_progress (

--- a/infra/db/provision_external_pgvector_store.sql
+++ b/infra/db/provision_external_pgvector_store.sql
@@ -16,6 +16,11 @@
 -- Source of truth: apps/frontend/src/db/schema.ts (documents/doc-group/
 -- embeddings subset) + apps/frontend/src/db/migrations/0001_custom_functions.sql.
 -- See docs/external-connections-setup.md for the full setup walkthrough.
+--
+-- This script provisions a NEW store and must always reflect the latest schema.
+-- Bringing an ALREADY-provisioned store up to date is the job of the ordered
+-- scripts in infra/db/external-migrations/ — any document-related change made
+-- here needs a matching numbered file there. See that directory's README.
 
 BEGIN;
 

--- a/infra/db/provision_external_pgvector_store.sql
+++ b/infra/db/provision_external_pgvector_store.sql
@@ -275,10 +275,17 @@ BEGIN
 
         raise log 'id of document group: %', v_doc_group_id;
 
-        -- Upsert the association in documents_doc_groups
-        INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
-        VALUES (v_document_id, v_doc_group_id)
-        ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        -- Upsert the association in documents_doc_groups.
+        -- Concurrent delete between SELECT and INSERT: no-op (do not fail ingest).
+        BEGIN
+            INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
+            VALUES (v_document_id, v_doc_group_id)
+            ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        EXCEPTION
+            WHEN foreign_key_violation THEN
+                RAISE LOG 'add_document_to_group: skipping FK violation for document_id=% doc_group_id=%',
+                    v_document_id, v_doc_group_id;
+        END;
 
         raise log 'completed for %',v_doc_group_id;
     END LOOP;
@@ -325,10 +332,17 @@ BEGIN
 
         raise log 'id of document group: %', v_doc_group_id;
 
-        -- Upsert the association in documents_doc_groups
-        INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
-        VALUES (v_document_id, v_doc_group_id)
-        ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        -- Upsert the association in documents_doc_groups.
+        -- Concurrent delete between SELECT and INSERT: no-op (do not fail ingest).
+        BEGIN
+            INSERT INTO public.documents_doc_groups(document_id, doc_group_id)
+            VALUES (v_document_id, v_doc_group_id)
+            ON CONFLICT (document_id, doc_group_id) DO NOTHING;
+        EXCEPTION
+            WHEN foreign_key_violation THEN
+                RAISE LOG 'add_document_to_group_url: skipping FK violation for document_id=% doc_group_id=%',
+                    v_document_id, v_doc_group_id;
+        END;
 
         raise log 'completed for %',v_doc_group_id;
     END LOOP;


### PR DESCRIPTION
## PR description

**Keep document group counts correct when documents are deleted**

Group counts are stored as a running total and maintained by the database whenever membership changes. Deleting a document never triggered that maintenance, for two independent reasons.

**What was wrong**
- The postgres database schemas never linked membership rows back to documents with a delete rule, so deleting a document left those rows behind and the stored count never moved and wrong even after a refresh. 
- The interface's immediate post-delete update used a membership test that could never match the shape of its data, so the on-screen count didn't move either. It also mutated cached state in place, which would have broken the undo path once that test started working.

**What this changes**
- Adds the missing delete rule to the schema definition and both provisioning paths, so the database keeps counts in sync on its own.
- Adds a repair step that clears membership rows already orphaned by past deletes, recalculates every drifted count, and only then enforces the new rule.
- Corrects the interface update to compare membership properly, produce fresh state instead of mutating the cache, and never render a negative count.
- Makes group assignment tolerate a document or group being deleted mid-ingest. Previously harmless, now a constraint violation.  Now treating it as a logged no-op rather than a failed ingest.

**Applying this to an existing database**

- In production: run `npm run db:migrate`. 
- On local: 
Apply the two files directly instead. Both are idempotent and safe to re-run:

```bash
docker exec -i self-hostable-uiuc-chat-postgres-illinois-chat-1 psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < apps/frontend/src/db/migrations/0013_documents_doc_groups_cascade.sql
```

```bash
docker exec -i self-hostable-uiuc-chat-postgres-illinois-chat-1 psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < apps/frontend/src/db/migrations/0014_add_document_to_group_fk_noop.sql
```

> Note: On local, db:migrate won't work if it's directly bootstrapped from the init schema. Since Drizzle's bookkeeping table is empty there, so it replays from the very first migration, spends its time on "already exists, skipping" notices, and fails before ever reaching this change. Those notices are not confirmation that anything was applied.


**Known and deliberate**
- **Deleting a group's last document leaves an empty group behind, while removing that same last document through the group UI deletes the group.** This asymmetry is inherited from production behavior and is intentionally preserved here rather than quietly changed. Flagging it explicitly because it reads like a bug and will likely come back as one.