### PR TITLE
fix(ci): bump trivy 0.49.1 -> 0.74.0 (upstream deleted the pinned release)

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -36,7 +36,7 @@ lint:
     - ruff@0.2.2
     - shellcheck@0.9.0
     - shfmt@3.6.0
-    - trivy@0.49.1
+    - trivy@0.74.0
     - yamllint@1.35.1
   ignore:
     - linters: [ALL]


### PR DESCRIPTION
One-line fix for the most urgent of the three things currently breaking Trunk CI. See #132 for the others.

## The problem

`.trunk/trunk.yaml` pinned `trivy@0.49.1`. **That release no longer exists** — aquasecurity deleted the tag and all its assets, so trunk's hermetic install 404s:

```
HTTP 404 'https://github.com/aquasecurity/trivy/releases/download/v0.49.1/trivy_0.49.1_Linux-64bit.tar.gz'
```

A tool that cannot install is a **hard failure in trunk, independent of findings**. Verified in isolation, running only trivy against one clean file:

```
Checked 0 files
✖ No issues, 1 failure      → exit code 1
```

Zero issues, still exit 1. So every PR touching a file trivy handles — YAML, Dockerfiles, IaC — fails regardless of its contents.

This was masked until now: PR #131's run passed only because its diff was entirely `.github/**` and `.trunk/**`, both ignored by all linters, so trivy was never fetched. The first real PR to hit the newly-enabled gate fails on this alone.

## The fix

`trivy@0.49.1` → `trivy@0.74.0`.

0.74.0 keeps the asset naming trunk's (v1.4.3) plugin URL template expects — `trivy_0.74.0_Linux-64bit.tar.gz`, `trivy_0.74.0_macOS-ARM64.tar.gz` — so no plugin bump is needed. Staying near the old pin is not an option: the whole 0.50–0.65 range was purged upstream too.

Verified locally: installs cleanly, runs, exit 0.

## What this surfaces — your call, not fixed here

With trivy actually running again, it reports **10 findings across 4 Dockerfiles**:

| Rule | Count | Finding |
|---|---|---|
| `DS-0002` | 4 | No non-root `USER` specified |
| `DS-0026` | 3 | No `HEALTHCHECK` instruction |
| `DS-0029` | 3 | `apt-get install` without `--no-install-recommends` |

Files: `apps/backend/Dockerfile.ecs`, `apps/backend/ai_ta_backend/rabbitmq/Dockerfile`, `apps/crawlee/Dockerfile`, `apps/frontend/Dockerfile`.

**These are reported at `0:0`** — file-level, no real line to anchor to. So like whole-file formatter issues, hold-the-line cannot suppress them, and any PR touching one of those four Dockerfiles will fail on them.

I deliberately did **not** suppress them here. `DS-0002` in particular (containers running as root) is a real finding, not lint noise, and silencing security rules should be a deliberate decision rather than a side effect of a version bump.

Three options, all reasonable:
1. Fix the Dockerfiles — add a non-root `USER`, `HEALTHCHECK`, and `--no-install-recommends`. Real improvement; touches runtime behavior, so it wants testing.
2. Disable `DS-0002` / `DS-0026` / `DS-0029` in `.trunk/trunk.yaml` if they don't match how you deploy (e.g. ECS handles health checks).
3. Leave as-is and accept that Dockerfile PRs fail until 1 or 2 happens.

## Net effect

Strictly an improvement either way. Before: *any* trivy-applicable file → hard failure with zero findings. After: only the 4 Dockerfiles with genuine findings fail, and the rest of the repo gets working security scanning for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)